### PR TITLE
Introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
Security Update が 1 つ来ているので、この際 Dependabot を導入しちゃおうかと思いました。一旦、毎週月曜日の 10:00 に作られるようにしてます。

* .github/ 以下の GitHub Actions
* package-lock.json

[CODEOWNERS](https://github.com/route06/actions/blob/2ce39eef180e43791e7c1c62f724768630e49bf4/.github/CODEOWNERS) を設定しているので、assignees は設定しませんでした。

Security Update の運用方法あんまり分かってないので、こうすると良いよなどあれば教えてください！

あと、PR には必ず Issue を紐づけて欲しいなどあれば、こちらもお知らせください。
