### PR TITLE
Fix permissions of add_assignee_to_pr.yml

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -12,6 +12,9 @@
 on:
   workflow_call:
 
+permissions:
+  pull-requests: write
+
 jobs:
   add-assignee-to-pr:
     name: Add assignee to PR


### PR DESCRIPTION
## 変更概要

add_assignee_to_pr.yml に permissions を追加します。

PR #3 で追加されるはずが、結果的に追加されなかったようです。

🔗 https://github.com/route06/actions/pull/3/commits

1. 8cd205e2f8c3a0a01745b45bac20719240886545
    * 関係ない変更
1. 5a3edc583aea1eb6591c528fed5e60bd7a5e0b2d
    * _add-assignee-to-pr.yml から permissions 設定削除 ← ❓
    * add-assignee-to-pr.yml に permissions 設定追加 ✅
1. cb91130df02e1ce2ac21ca3cd5fee5e01806d355
    * 関係ない変更
1. bf99edc3db7fdc3fe36ffa69206867f4a7006a66
    * 関係ない変更
1. f2eb165967e60290296f737565fca65b2ebc11c4
    * add-assignee-to-pr.yml を setup-pr.yml にリネーム ← ここ ⚠️

## 補足

~~https://github.com/technote-space/assign-author/pull/261 がマージされれば、permissions は不要です。~~
良く見たら、README.md の変更なので間違い。
