### PR TITLE
Release 時に v2 等の git tag が最新の v2.Y.Z を指すように書き換える

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -21,3 +21,22 @@ jobs:
         uses: Songmu/tagpr@0a9b8e6634db66e773516828c1359dc6e9e8b484 # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  bump_major_tag:
+    # When (3) above, the if condition is satisfied.
+    # Major version of git tag, such as v2, is updated.
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    needs: tagpr
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Tag new target
+        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+      - name: Push new tag
+        run: git push origin ${{ github.event.inputs.major_version }} --force

--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -18,9 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: tagpr
+        id: run-tagpr
         uses: Songmu/tagpr@0a9b8e6634db66e773516828c1359dc6e9e8b484 # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
   bump_major_tag:
     # When (3) above, the if condition is satisfied.
     # Major version of git tag, such as v2, is updated.
@@ -36,7 +39,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Get major version
+        run: echo "MAJOR_VERSION=$(echo ${{ needs.tagpr.outputs.tagpr-tag }} | sed -e 's/\(v[0-9]\+\)\..*/\1/')" >> $GITHUB_ENV
       - name: Tag new target
-        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+        run: git tag -f ${{ env.MAJOR_VERSION }} ${{ needs.tagpr.outputs.tagpr-tag }}
       - name: Push new tag
-        run: git push origin ${{ github.event.inputs.major_version }} --force
+        run: git push origin ${{ env.MAJOR_VERSION }} --force

--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -40,7 +40,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Get major version
-        run: echo "MAJOR_VERSION=$(echo ${{ needs.tagpr.outputs.tagpr-tag }} | sed -e 's/\(v[0-9]\+\)\..*/\1/')" >> $GITHUB_ENV
+        run: echo "MAJOR_VERSION=$(echo ${{ needs.tagpr.outputs.tagpr-tag }} | cut -d '.' -f 1)" >> $GITHUB_ENV
       - name: Tag new target
         run: git tag -f ${{ env.MAJOR_VERSION }} ${{ needs.tagpr.outputs.tagpr-tag }}
       - name: Push new tag

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ ROUTE06内外から使われることを想定したGitHub ActionsのReusable Wo
 npm install
 npm run adr:new タイトル
 ```
+
+### リリース方法
+
+1. 前回のリリース以降に main ブランチに commit が追加されると、Release PR が作られます
+    * 例: https://github.com/route06/actions/pull/21
+1. デフォルトではパッチバージョンが 1 つ上がります
+    * メジャーバージョンを上げたい時は `tagpr:major` ラベルを、マイナーバージョンを上げたい時は `tagpr:minor` ラベルを付けて下さい
+1. マージすると [Releases](https://github.com/route06/actions/releases) に、新しいバージョンのリリースが作られます
+    * 加えて、v2 などのタグが最新の v2.Y.Z を指すように、git tag が書き換えられます

--- a/docs/adr/004-tagprの導入.md
+++ b/docs/adr/004-tagprの導入.md
@@ -20,5 +20,5 @@
 
 - tagprが自動的に作成するRelease PRをマージするだけで、[Releases](https://github.com/route06/actions/releases) へのリリースが完了する
     - デフォルトではパッチバージョンが1つ上がったリリースが作られる
-    - Release PRに `tagpr:major` ラベルを付ければメジャーバージョンが、`tagpr:minor` ラベルを付ければパッチバージョンが1つ上がる
+    - Release PRに `tagpr:major` ラベルを付ければメジャーバージョンが、`tagpr:minor` ラベルを付ければマイナーバージョンが1つ上がる
 - 初見では以上の仕組みが分からないと思うので、README.mdにリリースフローを記載する


### PR DESCRIPTION
## 変更概要

PR https://github.com/route06/actions/pull/20 によって、Release PR が無事作られた。

* https://github.com/route06/actions/pull/21

本 PR では、以下を実装する。

* Release 時に v2 等の git tag が最新の v2.Y.Z を指すように書き換える
    * 今までは手動でのリリース後に、ローカルでの git 操作で更新していた
* README.md にリリースフローを追加する
