### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -35,6 +35,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Git config
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## 変更概要

Release PR https://github.com/route06/actions/pull/21 のマージをトリガーに発動した Release workflow で、以下のエラーが発生した。

🔗 https://github.com/route06/actions/actions/runs/9183827570/job/25255161968

> Run git tag -f v2 v2.0.2
> 　git tag -f v2 v2.0.2
> 　shell: /usr/bin/bash -e {0}
> 　env:
> 　　MAJOR_VERSION: v2
> fatal: Failed to resolve 'v2.0.2' as a valid ref.
> Error: Process completed with exit code 128.

v2 タグの更新時のエラー。本 PR ではこれを修正する。
