### PR TITLE
Avoid concurrent release workflow

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   tagpr:
     # (1) Create a release pull request.


### PR DESCRIPTION
確率は低いと思いますが、Release workflow が同時実行されると意図しないことが起こりそうなので、対策しました。

参考情報:
[コンカレンシーの使用 \- GitHub Docs](https://docs.github.com/ja/actions/using-jobs/using-concurrency)
