### PR TITLE
maintenance: change section and add label for release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,9 +12,10 @@ changelog:
     - title: "Fix bug :bug:"
       labels:
         - bug
-    - title: "Update modules :up:"
+    - title: "Maintenance :technologist:"
       labels:
         - dependencies
+        - maintenance
     - title: "Other Changes"
       labels:
         - "*"


### PR DESCRIPTION
## 概要

release.ymlのセクションとして `Maintenance 🧑‍💻` を追加し、 https://github.com/route06/actions/labels/maintenance label を含めるようにしました。

## 背景

https://github.com/route06/actions/pull/31 は今Other Changesにまとめられていますが、利用者に関係ない変更であり、このリポジトリのメンテナンスであることを伝えられると良さそうなためです。
