### PR TITLE
Introduce actionlint workflow

### DIFF
--- a/.github/workflows/gh_discussion_comment_to_slack.yml
+++ b/.github/workflows/gh_discussion_comment_to_slack.yml
@@ -29,17 +29,21 @@ jobs:
       # - 一度変数に入れることで、$や`をエスケープしている
       # - printfしないといい感じに"\n"が変換されない
       # - ref: https://times.hrbrain.co.jp/entry/2021/11/16/github-discussions-noti
-      - run: |
+      - name: Post to Slack
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          DISCUSSION_TITLE: ${{ toJSON(github.event.discussion.title) }}
+        run: |
           set -o pipefail
           body=$(
           cat <<"EOF"
-          ${{ github.event.comment.body }}
+          $COMMENT_BODY
           EOF
           )
           printf -v markdown_message_escaped %b "$body"
           jq -n \
           --arg pretext "New discussion comment by <${{ github.event.comment.user.html_url }}|${{ github.event.comment.user.login }}>" \
-          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} \"${{ toJSON(github.event.discussion.title) }}\">*" \
+          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} \"$DISCUSSION_TITLE\">*" \
           --arg text "$markdown_message_escaped" '
             {
             	"attachments": [

--- a/.github/workflows/gh_discussion_comment_to_slack.yml
+++ b/.github/workflows/gh_discussion_comment_to_slack.yml
@@ -39,7 +39,7 @@ jobs:
           printf -v markdown_message_escaped %b "$body"
           jq -n \
           --arg pretext "New discussion comment by <${{ github.event.comment.user.html_url }}|${{ github.event.comment.user.login }}>" \
-          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} "${{ toJSON(github.event.discussion.title) }}">*" \
+          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} \"${{ toJSON(github.event.discussion.title) }}\">*" \
           --arg text "$markdown_message_escaped" '
             {
             	"attachments": [

--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -45,7 +45,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Get major version
-        run: echo "MAJOR_VERSION=$(echo ${{ needs.tagpr.outputs.tagpr-tag }} | cut -d '.' -f 1)" >> $GITHUB_ENV
+        run: echo "MAJOR_VERSION=$(echo ${{ needs.tagpr.outputs.tagpr-tag }} | cut -d '.' -f 1)" >> "$GITHUB_ENV"
       - name: Tag new target
         run: git tag -f ${{ env.MAJOR_VERSION }} ${{ needs.tagpr.outputs.tagpr-tag }}
       - name: Push new tag

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      checks: write
       contents: read
       pull-requests: write
     steps:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint with reviewdog
+        uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Give actionlint error
         run: |
           echo 'AAA=aaa' >> $GITHUB_ENV
+      - name: Give actionlint error2
+        run: |
+          echo 'BBB=bbb' >> $GITHUB_ENV
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
         with:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -16,12 +16,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Give actionlint error
-        run: |
-          echo 'AAA=aaa' >> $GITHUB_ENV
-      - name: Give actionlint error2
-        run: |
-          echo 'BBB=bbb' >> $GITHUB_ENV
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
         with:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
+        with:
+          fail_on_error: true

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -10,9 +10,16 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
         with:
+          fail_on_error: true
           filter_mode: nofilter
+          level: error
+          reporter: github-pr-review

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -16,6 +16,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: Give actionlint error
+        run: |
+          echo 'AAA=aaa' >> $GITHUB_ENV
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
         with:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      checks: write
       contents: read
       pull-requests: write
     steps:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@fd627997c9688c2f39e13917aed23873c031b834 # v1.48.0
         with:
-          fail_on_error: true
+          filter_mode: nofilter

--- a/.github/workflows/notify_slack_on_ci_failed.yml
+++ b/.github/workflows/notify_slack_on_ci_failed.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Set COMMIT_MESSAGE
-        run: echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> $GITHUB_ENV
+        run: echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> "$GITHUB_ENV"
       - name: Notify to slack
         uses: tokorom/action-slack-incoming-webhook@main
         env:

--- a/.github/workflows/notify_slack_on_ci_failed.yml
+++ b/.github/workflows/notify_slack_on_ci_failed.yml
@@ -27,7 +27,9 @@ jobs:
 
     steps:
       - name: Set COMMIT_MESSAGE
-        run: echo "COMMIT_MESSAGE=${{ github.event.head_commit.message }}" | tr '\n' ' ' >> "$GITHUB_ENV"
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" | tr '\n' ' ' >> "$GITHUB_ENV"
       - name: Notify to slack
         uses: tokorom/action-slack-incoming-webhook@main
         env:


### PR DESCRIPTION
ref. https://github.com/route06/actions/issues/4

## 変更概要

セキュアな Reusable Workflow を提供し続けるために、このリポジトリの CI に [rhysd/actionlint](https://github.com/rhysd/actionlint) を導入します。

トリガーは以下のとおりです。

* main ブランチへの commit 追加
* Pull request 作成時

`rhysd/actionlint` は [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint) を介して使用します。actionlint のエラーは https://github.com/route06/actions/pull/35#discussion_r1639539282 のように、Pull request のコメントとして指摘されます。

actionlint で指摘があった既存の workflow も 29fcf0a0dc2b65f04d67e8822035607a4d96da7a...26c5a95d6d97eb45bb54692e83e36ef0611fe9f1 で修正しています。

## TODO

* [x] このリポジトリへの PR 作成時と、main ブランチへのマージ時に actionlint が実行されるようにする
* [x] ~~ADR の作成？~~

## 参考情報

* [GitHub Actions のワークフローをチェックする actionlint をつくった \- はやくプログラムになりたい](https://rhysd.hatenablog.com/entry/2021/07/11/214313)
    * https://github.com/rhysd/actionlint
* [社内用GitHub Actionsのセキュリティガイドラインを公開します \| メルカリエンジニアリング](https://engineering.mercari.com/blog/entry/20230609-github-actions-guideline/)
    * https://github.com/reviewdog/action-actionlint
    * https://github.com/reviewdog/reviewdog
