### PR TITLE
maintenance: Setup merge queue and remove push event

### DIFF
--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -1,10 +1,8 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 概要

リポジトリにマージキューを設定しました！このPRのマージボタンも以下のように `Merge when ready` と表記が変わっています。

<img width="830" alt="スクリーンショット 2024-06-17 18 21 51" src="https://github.com/route06/actions-repo-tasks/assets/31152321/72826efd-3280-4b6c-b425-1409392b594e">

これにより、 `Merge when ready` を押すとマージキューに追加され、mainブランチを取り込んだ状態でCIを実行した後、成功した場合のみmainブランチにマージされます。これにより複数PRの競合があった際にmainブランチが不正な状態になることを防ぐことができます。

マージキュー上でのみ失敗するCIをデバッグとして用意するのは難しいのですが、すでに社内で運用されている設定内容と同一のためおそらく問題はないと思っています。以下の記事で掲載しているスクリーンショットと同一です:

[モノレポでマージキューと必須ステータスチェックを運用するためのTips - ROUTE06 Tech Blog](https://tech.route06.co.jp/entry/2024/06/12/121511)

このPRのマージ時に、マージキューの挙動を録画してPRのコメントに残す予定です。

## 備考

<details><summary>リポジトリのSettingsでのブランチ保護ルールの設定内容</summary>
<p>

<img width="697" alt="スクリーンショット 2024-06-17 18 44 18" src="https://github.com/route06/actions/assets/31152321/9360c1c0-4132-4716-a5ac-1c76196c201c">


</p>
</details> 
