### PR TITLE
Fix gh_discussion_comment_to_slack.yml part2

### DIFF
--- a/.github/workflows/gh_discussion_comment_to_slack.yml
+++ b/.github/workflows/gh_discussion_comment_to_slack.yml
@@ -43,7 +43,7 @@ jobs:
           printf -v markdown_message_escaped %b "$body"
           jq -n \
           --arg pretext "New discussion comment by <${{ github.event.comment.user.html_url }}|${{ github.event.comment.user.login }}>" \
-          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} ${{ toJSON(env.DISCUSSION_TITLE) }}>*" \
+          --arg title "*<${{ github.event.comment.html_url }}|Comment on #${{ toJSON(github.event.discussion.number) }} ${{ env.DISCUSSION_TITLE }}>*" \
           --arg text "$markdown_message_escaped" '
             {
             	"attachments": [


### PR DESCRIPTION
## 概要

https://github.com/route06/actions/pull/41 の 6d7829e66043eda3f84d2f452c0eb8b2539ec496 に問題があった。ディスカッションタイトルに半角スペースが含まれていると、jq parse error が発生する。

Before（jq parse error が発生する）:

```
--arg title "*<https://github.com/org/repo/discussions/123#discussioncomment-9876543|Comment on #123 "2024/06/18 ミーティングタイトル">*"
```

After（jq parse error が修正される）:

```
--arg title "*<https://github.com/org/repo/discussions/123#discussioncomment-9876543|Comment on #123 2024/06/18 ミーティングタイトル>*"
```

## 変更内容

toJSON することで `ミーティングタイトル` が `"ミーティングタイトル"` になる気がするので、toJSON を削除した。

https://github.com/route06/actions/pull/41 の前の https://github.com/route06/actions/pull/35 で、環境変数を使ったことで、shell injection の問題は解決できたはず。

そもそも参考にした 31 行目の記事で toJSON は使っていない。
[【GitHub Actions】GitHub DiscussionsをSlackで通知する \- HRBrain Blog](https://times.hrbrain.co.jp/entry/2021/11/16/github-discussions-noti)
どういう経緯で toJSON を入れたのだろう？