### PR TITLE
fix missing permission for my_setup_pr.yml

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -8,6 +8,8 @@
 #     types: [opened]
 # jobs:
 #   add-assignee-to-pr:
+#     permissions:
+#       pull-requests: write
 #     uses: route06/actions/.github/workflows/add_assignee_to_pr.yml@v2
 on:
   workflow_call:

--- a/.github/workflows/my_setup_pr.yml
+++ b/.github/workflows/my_setup_pr.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   add-assignee-to-pr:
+    permissions:
+      pull-requests: write
     uses: ./.github/workflows/add_assignee_to_pr.yml


### PR DESCRIPTION
🔗 https://github.com/route06/actions/actions/runs/9560315162

> [Invalid workflow file: .github/workflows/my_setup_pr.yml#L8](https://github.com/route06/actions/actions/runs/9560315162/workflow)
> The workflow is not valid. .github/workflows/my_setup_pr.yml (Line: 8, Col: 3): Error calling workflow 'route06/actions/.github/workflows/add_assignee_to_pr.yml@5622884443da96cddf8ac859ef947f85551e80ed'. The nested job 'add-assignee-to-pr' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

今度は https://github.com/route06/actions/pull/38 の 7d387d8736822a2535fa391399b9eda001b65abb でのエンバグです 🙇

上記エラーメッセージによると、ネストされた子供の workflow で要求する permissions は、呼び元の親 workflow で明示的に指定する必要があるそうです。知りませんでしたorz
