### PR TITLE
Use full changeset hash for 3rd-party GitHub Actions

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -25,4 +25,4 @@ jobs:
     if: ${{ github.event.pull_request.user.type != 'Bot' && toJSON(github.event.pull_request.assignees) == '[]' }}
 
     steps:
-      - uses: technote-space/assign-author@v1
+      - uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160 # v1.6.2

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -31,4 +31,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: ls-lint/action@v2.2.3
+      - uses: ls-lint/action@1887e6c0e7f2dfa81a2d67591f0eb7782720026f # v2.2.3

--- a/.github/workflows/notify_slack_on_ci_failed.yml
+++ b/.github/workflows/notify_slack_on_ci_failed.yml
@@ -31,7 +31,7 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" | tr '\n' ' ' >> "$GITHUB_ENV"
       - name: Notify to slack
-        uses: tokorom/action-slack-incoming-webhook@main
+        uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
         env:
           INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/docs/adr/005-サードパーティのgithub-actionsのバージョンをfull-changeset-hashで固定する.md
+++ b/docs/adr/005-サードパーティのgithub-actionsのバージョンをfull-changeset-hashで固定する.md
@@ -1,0 +1,54 @@
+# 5. サードパーティのGitHub ActionsのバージョンをFull Changeset Hashで固定する
+
+## ステータス
+
+- [ ] 提案中
+- [x] 承認
+- [ ] 否認
+- [ ] 廃止
+- [ ] 保留
+
+## 背景
+
+今後、このリポジトリでの Reusable Workflow 提供を広めるにあたり、よりセキュアで壊れづらいな Workflow を提供していきたい。
+
+## 決定
+
+サードパーティの GitHub Actions のバージョンを Full Changeset Hash で固定する。バージョンコメントも記載する。
+
+```yaml
+- uses: owner/action-name@v1.0.0
+# ↓
+- uses: owner/action-name@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v1.0.0
+```
+
+### サードパーティ以外の GitHub Actions はなぜ固定しないか？
+
+サードパーティ以外とは、例えば [actions/checkout](https://github.com/marketplace/actions/checkout) のような Verified creator のこと。
+
+🔗 [Marketplaceバッジについて \- GitHub Docs](https://docs.github.com/ja/apps/github-marketplace/github-marketplace-overview/about-marketplace-badges)
+
+> GitHubは、アプリケーションを分析しません。 Marketplaceバッジは、パブリッシャーが上記の条件を満たしているということを確認しているだけに過ぎません。
+
+Verified creator であっても、安全性が担保されているわけではない。
+
+すべての GitHub Actions を Full Changeset Hash で固定すると、Dependabot version update による週次 PR 対応が増える。また、Full Changeset Hash で固定しても、安全性が完全に担保されるわけでもない。
+
+そのため、今回は Verified creator でのバージョン固定は見送った。
+
+## 影響
+
+良い影響:
+
+* サードパーティの GitHub Actions で git のタグが書き換えられても影響を受けない
+* `owner/action-name@main` のような壊れやすい指定を排除できる
+
+悪い影響:
+
+* サードパーティの GitHub Actions を初めて導入する時に、若干の手間がかかる
+
+中立的な影響:
+
+* Dependabot version update には影響ない[^1]
+
+[^1]: 例: https://github.com/route06/actions/pull/46#discussion_r1650261916

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,3 +4,4 @@
 * [2. セマンティックバージョニングの採用](002-セマンティックバージョニングの採用.md)
 * [3. ワークフローの命名規則](003-ワークフローの命名規則.md)
 * [4. tagprの導入](004-tagprの導入.md)
+* [5. サードパーティのgithub-actionsのバージョンをfull-changeset-hashで固定する](005-サードパーティのgithub-actionsのバージョンをfull-changeset-hashで固定する.md)


### PR DESCRIPTION
## 変更内容

サードパーティの GitHub Actions のバージョンを Full Changeset Hash での固定に変更する。

```yaml
- uses: owner/action-name@v1.0.0
# ↓
- uses: owner/action-name@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v1.0.0
```

👈 の GitHub Actions について、変更した

| Action name | Verified creator | Next action |
|---|:---:|---|
| [actions/checkout](https://github.com/marketplace/actions/checkout) | ✅ | Verified creator なので移行しない |
| [actions/setup-java](https://github.com/marketplace/actions/setup-java-jdk) | ✅ | Verified creator なので移行しない |
| [dorny/paths-filter](https://github.com/marketplace/actions/paths-changes-filter) | | 移行済なので何もしない |
| [github/codeql-action/analyze](https://github.com/github/codeql-action/tree/main/analyze)[^1] |  | Verified creator の明記はないが GitHub 製なので移行しない |
| [github/codeql-action/autobuild](https://github.com/github/codeql-action/tree/main/autobuild)[^1] |  | Verified creator の明記はないが GitHub 製なので移行しない |
| [github/codeql-action/init](https://github.com/github/codeql-action/tree/main/init)[^1] |  | Verified creator の明記はないが GitHub 製なので移行しない |
| [ls-lint/action](https://github.com/ls-lint/action)[^2] |  | 移行した 👈 |
| [octokit/graphql-action](https://github.com/marketplace/actions/github-graphql-api-query) | ✅ | Verified creator なので移行しない |
| [reviewdog/action-actionlint](https://github.com/marketplace/actions/actionlint-with-reviewdog) |  | 移行済なので何もしない |
| [Songmu/tagpr](https://github.com/marketplace/actions/automate-pull-request-generation-and-tagging-for-releases-using-tagpr) | | 移行済なので何もしない |
| [technote-space/assign-author](https://github.com/marketplace/actions/assign-author) |  | 移行した 👈 |
| [tokorom/action-slack-incoming-webhook](https://github.com/marketplace/actions/slack-incoming-webhook) |  | 移行した 👈 |

[^1]: GitHub Marketplace に公開されていない理由: https://github.com/github/codeql-action/issues/596#issuecomment-868569180
[^2]: GitHub Marketplace に公開されていない

## 背景・目的

このリポジトリ https://github.com/route06/actions をよりセキュアにするため。

🔗 [社内用GitHub Actionsのセキュリティガイドラインを公開します \| メルカリエンジニアリング](https://engineering.mercari.com/blog/entry/20230609-github-actions-guideline/)

> サードパーティのActionを利用する場合、基本的にFull Changeset Hashに固定する。以下のようにFull Changeset Hashとバージョンコメントを記載することで、どのバージョンを使っているのかわかりやすくなる。
>
> * Dependabot
>     * https://github.com/dependabot/dependabot-core/pull/5951
>     * [Dependabot now updates comments in GitHub Actions workflows referencing action versions \- The GitHub Blog](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/)

Dependabot は Full Changeset Hash に対応している[^3]ため、Full Changeset Hash に変更するデメリットはサードパーティの GitHub Action を初めて導入する時だけ。

[^3]: https://github.com/route06/actions/pull/46#discussion_r1650261916

## TODO

* [x] サードパーティの GitHub Actions のバージョン指定を full changeset hash に変更する
* [x] ADR の作成

## 関連情報

* [CI/CDでサードパーティスクリプト・バイナリを使う際の注意点 \- ROUTE06 Tech Blog](https://tech.route06.co.jp/entry/2023/08/23/082500)
