### PR TITLE
maintenance: use github app token

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -15,16 +15,20 @@ jobs:
     # (3) If the release pull request is merged, create a new git tag and GitHub release.
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@ad38cffc07bac6e3857755914c4c88bfd2db4da4 # v1.10.2
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_CI_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_CI_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: tagpr
         id: run-tagpr
         uses: Songmu/tagpr@0a9b8e6634db66e773516828c1359dc6e9e8b484 # v1.3.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
     outputs:
       tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
   bump_major_tag:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -17,14 +17,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@ad38cffc07bac6e3857755914c4c88bfd2db4da4 # v1.10.2
-        id: app-token
-        with:
-          app-id: ${{ vars.ACTIONS_CI_APP_ID }}
-          private-key: ${{ secrets.ACTIONS_CI_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@afad3b6ab835e5611bda8c8193377e2d5c21413d # v1.51.0
         with:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -17,7 +17,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@ad38cffc07bac6e3857755914c4c88bfd2db4da4 # v1.10.2
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_CI_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_CI_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Run actionlint with reviewdog
         uses: reviewdog/action-actionlint@afad3b6ab835e5611bda8c8193377e2d5c21413d # v1.51.0
         with:


### PR DESCRIPTION
## 変更内容

tagprによるリリースPRの作成時、使用するトークンをGitHub App経由のトークンにしました。

## 背景

https://github.com/route06/actions/pull/40 でマージキューを導入し、それによりPRは必須ステータスチェックを通さないとマージできなくなりました。人間によって作成するPRであれば問題ありませんが、tagprによるリリースPRはデフォルトのトークンではCIが発火せず、必須ステータスチェックが通らなくなってしまいました。
これをGitHub App経由のトークンにすることでCIが発火するようになる想定です。

## 動作確認

動作確認用のデバッグコミットとして別のCIでGitHub App経由のトークンを利用し、取り急ぎContentの取得(= actions/checkoutによるチェックアウト)ができることを確認しました。

<img width="916" alt="スクリーンショット 2024-06-28 18 52 09" src="https://github.com/route06/actions/assets/31152321/bd5bcd50-983c-4bd6-9adc-667c33dfe94a">

ref: https://github.com/route06/actions/actions/runs/9710893014/job/26802526164

tagprが行うのはPRの作成とContentの更新であり、後者の確認ができた形です。前者についてはこのPRのマージ後作成されるPRで確認できればと思います。

## TODO

- このPRをマージ後作成されるリリースPRで以下を確認する
    - CIが発火し、テストが実行され、必須ステータスチェックが通っていること
    - CHANGELOGの更新コミットが成功していること
