### PR TITLE
workflows/create_discussion.yml で空のテンプレートファイルを許容する

### DIFF
--- a/.github/workflows/create_discussion.yml
+++ b/.github/workflows/create_discussion.yml
@@ -2,15 +2,32 @@
 #
 # on:
 #   schedule:
-#     - cron: "0 0 * * mon"
+#     # 毎週水曜 13:00 JST
+#     - cron: "0 4 * * wed"
+#
+# env:
+#   # NOTE: MTG開催曜日に合わせて変更してください
+#   TARGET_DAY: "wednesday"
+#
 # jobs:
 #   create_discussion:
-#     uses: route06/actions/.github/workflows/create_discussion.yml@v2
-#     with:
-#       target_day: sunday
-#       title: ハドル
-#       discussion_category_slug: meeting-notes
-#       description_template_path: _templates/weekly_meeting_discussion/test.md
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 10
+#     env:
+#       TZ: "Asia/Tokyo"
+#     steps:
+#       - name: Get next meeting date
+#         id: get_date
+#         run: |
+#           target_date=$(date -d "next $TARGET_DAY" +%Y/%m/%d)
+#           echo "target_date=$target_date" >> "$GITHUB_OUTPUT"
+#
+#       - name: Run create discussion workflow
+#         uses: route06/actions/.github/workflows/create_discussion.yml@v2
+#         with:
+#           title: ${{ steps.get_date.outputs.target_date }} Meeting Title
+#           discussion_category_slug: meeting-notes
+#           description_template_path: _templates/weekly_meeting_discussion/test.md
 #
 # 補足:
 # discussion_category_slug は各カテゴリを選択した時の、URL 末尾の文字列です。以下は例です。
@@ -24,12 +41,8 @@ name: Create discussion
 on:
   workflow_call:
    inputs: 
-    target_day:
-      description: MTG開催曜日に合わせて変更してください。
-      required: true
-      type: string
     title:
-      description: 作成するDiscussionのタイトルを設定してください（yyyy/mm/dd が接頭辞として自動付与されます）。
+      description: 作成するDiscussionのタイトルを設定してください。
       required: true
       type: string
     discussion_category_slug:
@@ -51,15 +64,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: "Get next meeting date"
-        id: get_date
-        run: |
-          target_date=$(date -d "next ${{ inputs.target_day }}" +%Y/%m/%d)
-          echo "target_date=$target_date" >> "$GITHUB_OUTPUT"
-
       - name: Run script
         env:
-          TARGET_DATE: ${{ steps.get_date.outputs.target_date }}
           REPOSITORY: ${{ github.repository }}
           DISCUSSION_CATEGORY_SLUG: ${{ inputs.discussion_category_slug }} 
           TITLE: ${{ inputs.title }}
@@ -92,7 +98,7 @@ jobs:
               return {repositoryId: result.repository.id, categoryId: result.repository.discussionCategory.id};
             }
 
-            async function createWeeklyReportDiscussion(github, repositoryId, categoryId, title, description) {
+            async function createMyDiscussion(github, repositoryId, categoryId, title, description) {
               const result = await github.graphql(`mutation($repositoryId:ID!, $categoryId:ID!, $title:String!, $body:String!) {
                 createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
                   discussion {
@@ -107,7 +113,7 @@ jobs:
               });
             }
 
-            const { REPOSITORY, DISCUSSION_CATEGORY_SLUG, TARGET_DATE, TITLE, DESCRIPTION_TEMPLATE_PATH } = process.env;
+            const { REPOSITORY, DISCUSSION_CATEGORY_SLUG, TITLE, DESCRIPTION_TEMPLATE_PATH } = process.env;
             const [owner, repositoryName] = REPOSITORY.split('/');
 
             const repositoryIdAndCategoryId = await featchRepoIdAndDiscussionCategoryId(
@@ -117,7 +123,7 @@ jobs:
               DISCUSSION_CATEGORY_SLUG,
             )
 
-            const discussionTitle = `${TARGET_DATE} ${TITLE}`;
+            const discussionTitle = TITLE;
 
             let description;
             try {
@@ -131,7 +137,7 @@ jobs:
               process.exit(1);
             }
 
-            const discussionId = await createWeeklyReportDiscussion(
+            const discussionId = await createMyDiscussion(
               github,
               repositoryIdAndCategoryId.repositoryId,
               repositoryIdAndCategoryId.categoryId,

--- a/.github/workflows/create_discussion.yml
+++ b/.github/workflows/create_discussion.yml
@@ -118,7 +118,18 @@ jobs:
             )
 
             const discussionTitle = `${TARGET_DATE} ${TITLE}`;
-            const description = fs.readFileSync(DESCRIPTION_TEMPLATE_PATH, "utf8");
+
+            let description;
+            try {
+              description = fs.readFileSync(DESCRIPTION_TEMPLATE_PATH, "utf8");
+              if (!description) {
+                console.warn('Description file is empty, using default description.');
+                description = 'Default description text';
+              }
+            } catch (error) {
+              console.error("Error reading description template file:", error);
+              process.exit(1);
+            }
 
             const discussionId = await createWeeklyReportDiscussion(
               github,

--- a/.github/workflows/create_discussion.yml
+++ b/.github/workflows/create_discussion.yml
@@ -1,8 +1,11 @@
+# todo: 以下はStarter Workflow化する
 # @usage
+#
+# name: Create discussion
 #
 # on:
 #   schedule:
-#     # 毎週水曜 13:00 JST
+#     # 毎週水曜 13:00 JST に実行
 #     - cron: "0 4 * * wed"
 #
 # env:
@@ -10,7 +13,7 @@
 #   TARGET_DAY: "wednesday"
 #
 # jobs:
-#   create_discussion:
+#   get_next_meeting_date:
 #     runs-on: ubuntu-latest
 #     timeout-minutes: 10
 #     env:
@@ -21,13 +24,19 @@
 #         run: |
 #           target_date=$(date -d "next $TARGET_DAY" +%Y/%m/%d)
 #           echo "target_date=$target_date" >> "$GITHUB_OUTPUT"
-#
-#       - name: Run create discussion workflow
-#         uses: route06/actions/.github/workflows/create_discussion.yml@v2
-#         with:
-#           title: ${{ steps.get_date.outputs.target_date }} Meeting Title
-#           discussion_category_slug: meeting-notes
-#           description_template_path: _templates/weekly_meeting_discussion/test.md
+#     outputs:
+#       target_date: ${{ steps.get_date.outputs.target_date }}
+# 
+#   create_discussion:
+#     needs: get_next_meeting_date
+#     uses: route06/actions/.github/workflows/create_discussion.yml@update-create-discussion-workflow-1
+#     with:
+#       # NOTE: 作成するDiscussionのタイトルを指定
+#       title: ${{ needs.get_next_meeting_date.outputs.target_date }} Meeting Title
+#       # NOTE: discussion_category_slugについては補足参照
+#       discussion_category_slug: meeting-notes
+#       # NOTE: 作成するDiscussionで使用するテンプレートファイルのパスを指定
+#       description_template_path: _templates/weekly_meeting_discussion/test.md
 #
 # 補足:
 # discussion_category_slug は各カテゴリを選択した時の、URL 末尾の文字列です。以下は例です。

--- a/.github/workflows/create_discussion.yml
+++ b/.github/workflows/create_discussion.yml
@@ -134,17 +134,21 @@ jobs:
 
             const discussionTitle = TITLE;
 
-            let description;
-            try {
-              description = fs.readFileSync(DESCRIPTION_TEMPLATE_PATH, "utf8");
-              if (!description) {
-                console.warn('Description file is empty, using default description.');
-                description = 'Default description text';
+            const description = (() => {
+              const DEFAULT_DESCRIPTION = '<!-- Write description here -->';
+              try {
+                const desc = fs.readFileSync(DESCRIPTION_TEMPLATE_PATH, "utf8");
+                return desc.trim() === '' ? DEFAULT_DESCRIPTION : desc;
+              } catch (error) {
+                if (error.code === 'ENOENT') {
+                  console.error("Error reading description template file:", error);
+                  return DEFAULT_DESCRIPTION;
+                }
+                else {
+                  throw error;
+                }
               }
-            } catch (error) {
-              console.error("Error reading description template file:", error);
-              process.exit(1);
-            }
+            })();
 
             const discussionId = await createMyDiscussion(
               github,


### PR DESCRIPTION
[この辺](https://github.com/route06/actions/pull/52#pullrequestreview-2159628912) の修正を入れています。

- description_template_path の中身が空の時はデフォルトコンテンツを入れる
    - 72cf002de0efec708da0cf06e09399f49767a94c
- ~~週次だけでなく、日次や月次のdiscussion作成でも使えるように、discussion作成だけにworkflowの処理を絞り、日付つきタイトルは呼び出し元で設定する~~
    - ~~83426dc9edc2e23f8e5e3ed188c50e522453bb5f~~
    - ~~Starter Workflowとしてパターンを作成する想定~~
        - ~~7f3562ed381ddaf38bb5815bdb791a64cba7372e~~

打ち消し線部分は別PRとする。