### PR TITLE
Pin actions/create-github-app-token to major version

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+      - uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_CI_APP_ID }}


### PR DESCRIPTION
🔗 https://github.com/route06/actions/pull/55#pullrequestreview-2162111686

> 別件になるが、[Create GitHub App Token は Verified creator](https://github.com/marketplace/actions/create-github-app-token) なので、メジャーバージョン指定でよいだろう（[ADR](https://github.com/route06/actions/blob/v2.1.7/docs/adr/005-%E3%82%B5%E3%83%BC%E3%83%89%E3%83%91%E3%83%BC%E3%83%86%E3%82%A3%E3%81%AEgithub-actions%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%92full-changeset-hash%E3%81%A7%E5%9B%BA%E5%AE%9A%E3%81%99%E3%82%8B.md)）。別で PR 作る。
