### PR TITLE
Rename create_discussion.yml to create_gh_discussion.yml

### DIFF
--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -29,7 +29,7 @@
 # 
 #   create_discussion:
 #     needs: get_next_meeting_date
-#     uses: route06/actions/.github/workflows/create_gh_discussion.yml@update-create-discussion-workflow-1
+#     uses: route06/actions/.github/workflows/create_gh_discussion.yml@v2
 #     with:
 #       # NOTE: 作成するDiscussionのタイトルを指定
 #       title: ${{ needs.get_next_meeting_date.outputs.target_date }} Meeting Title

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -29,7 +29,7 @@
 # 
 #   create_discussion:
 #     needs: get_next_meeting_date
-#     uses: route06/actions/.github/workflows/create_discussion.yml@update-create-discussion-workflow-1
+#     uses: route06/actions/.github/workflows/create_gh_discussion.yml@update-create-discussion-workflow-1
 #     with:
 #       # NOTE: 作成するDiscussionのタイトルを指定
 #       title: ${{ needs.get_next_meeting_date.outputs.target_date }} Meeting Title

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ROUTE06内外から使われることを想定したGitHub ActionsのReusable Wo
 
 * [add_assignee_to_pr.yml](./.github/workflows/add_assignee_to_pr.yml)
 * [codeql.yml](./.github/workflows/codeql.yml)
-* [create_discussion.yml](./.github/workflows/create_discussion.yml)
+* [create_gh_discussion.yml](./.github/workflows/create_gh_discussion.yml)
 * [get_last_discussion_url.yml](./.github/workflows/get_last_discussion_url.yml)
 * [gh_discussion_comment_to_slack.yml](./.github/workflows/gh_discussion_comment_to_slack.yml)
 * [notify_slack_on_ci_failed.yml](./.github/workflows/notify_slack_on_ci_failed.yml)


### PR DESCRIPTION
## 変更概要

💡 feature ブランチへの PR です。

"discussion" が GitHub Discussion を指すことは自明**ではない**ので、リネームしました。 1461a4f1adfe0b5c66c81c0a57161e47acfe19a6
※ [gh CLI](https://github.com/cli/cli) があるので、gh という省略名は許容されるかなと思っています。

一度 create_gh_discussion.yml という名前でリリースすると、リネームのような破壊的な変更をした時に v3 にメジャーアップデートしないといけなくなるので、現時点で変更したい気持ちがあります。

ついでに `@usage` の細かい間違いも修正しました。 bb3448fd752f45f880fb497506ceb8eb0f3f7dfd

## 補足

参考: [修正後の「利用可能なWorkflow」](https://github.com/route06/actions/tree/bb3448fd752f45f880fb497506ceb8eb0f3f7dfd?tab=readme-ov-file#%E5%88%A9%E7%94%A8%E5%8F%AF%E8%83%BD%E3%81%AAworkflow)
そういう意味では get_last_discussion_url.yml という名前に後悔...。
