### PR TITLE
Rename get_next_scheduled_date.yml to calc_next_date.yml

### DIFF
--- a/.github/workflows/calc_next_date.yml
+++ b/.github/workflows/calc_next_date.yml
@@ -1,26 +1,26 @@
 # @usage
 #
-# name: Get next scheduled date
+# name: Calc next date
 #
 # on:
 #   workflow_dispatch:
 #
 # jobs:
-#   get_next_weekly_scheduled_date:
-#     uses: route06/actions/.github/workflows/get_next_scheduled_date.yml@v2
+#   calc_next_weekly_date:
+#     uses: route06/actions/.github/workflows/calc_next_date.yml@v2
 #     with:
 #       interval: weekly
 #       target_day: wednesday
 #
 #   log_result:
 #     runs-on: ubuntu-latest
-#     needs: [get_next_weekly_scheduled_date]
+#     needs: [calc_next_weekly_date]
 #     steps:
-#       - name: Log the next scheduled date
+#       - name: Log the calculated next date
 #         run: |
-#           echo "The next weekly schedule date is: ${{ needs.get_next_weekly_scheduled_date.outputs.next_scheduled_date }}"
+#           echo "The next weekly date is: ${{ needs.calc_next_weekly_date.outputs.next_date }}"
 
-name: Get next scheduled date
+name: Calc next date
 
 on:
   workflow_call:
@@ -38,32 +38,32 @@ on:
         default: "Asia/Tokyo"
         type: string
     outputs:
-      next_scheduled_date:
+      next_date:
         description: yyyy/mm/dd形式で日付を返します。
-        value: ${{ jobs.get_next_scheduled_date.outputs.next_scheduled_date }}
+        value: ${{ jobs.calc_next_date.outputs.next_date }}
 
 jobs:
-  get_next_scheduled_date:
+  calc_next_date:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       TZ: ${{ inputs.time_zone }}
     steps:
       - name: Run script
-        id: get_date
+        id: calc_date
         run: |
           case "${{ inputs.interval }}" in
             "daily")
-                next_scheduled_date=$(date -d "tomorrow" +%Y/%m/%d)
+                next_date=$(date -d "tomorrow" +%Y/%m/%d)
                 ;;
             "weekly")
-                next_scheduled_date=$(date -d "next ${{ inputs.target_day }}" +%Y/%m/%d)
+                next_date=$(date -d "next ${{ inputs.target_day }}" +%Y/%m/%d)
                 ;;
             *)
                 echo "Invalid INTERVAL value"
                 exit 1
                 ;;
             esac
-            echo "next_scheduled_date=$next_scheduled_date" >> "$GITHUB_OUTPUT"
+            echo "next_date=$next_date" >> "$GITHUB_OUTPUT"
     outputs:
-      next_scheduled_date: ${{ steps.get_date.outputs.next_scheduled_date }}
+      next_date: ${{ steps.calc_date.outputs.next_date }}

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -8,31 +8,19 @@
 #     # 毎週水曜 13:00 JST に実行
 #     - cron: "0 4 * * wed"
 #
-# env:
-#   # NOTE: MTG開催曜日に合わせて変更してください
-#   TARGET_DAY: "wednesday"
-#
 # jobs:
 #   get_next_meeting_date:
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 10
-#     env:
-#       TZ: "Asia/Tokyo"
-#     steps:
-#       - name: Get next meeting date
-#         id: get_date
-#         run: |
-#           target_date=$(date -d "next $TARGET_DAY" +%Y/%m/%d)
-#           echo "target_date=$target_date" >> "$GITHUB_OUTPUT"
-#     outputs:
-#       target_date: ${{ steps.get_date.outputs.target_date }}
+#     uses: route06/actions/.github/workflows/calc_next_date.yml@v2
+#     with:
+#       interval: weekly
+#       target_day: wednesday # NOTE: MTG開催曜日に合わせて変更してください
 # 
 #   create_discussion:
 #     needs: get_next_meeting_date
 #     uses: route06/actions/.github/workflows/create_gh_discussion.yml@v2
 #     with:
 #       # NOTE: 作成するDiscussionのタイトルを指定
-#       title: ${{ needs.get_next_meeting_date.outputs.target_date }} Meeting Title
+#       title: ${{ needs.calc_next_weekly_date.outputs.next_date }} Meeting Title
 #       # NOTE: discussion_category_slugについては補足参照
 #       discussion_category_slug: meeting-notes
 #       # NOTE: 作成するDiscussionで使用するテンプレートファイルのパスを指定

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ ROUTE06内外から使われることを想定したGitHub ActionsのReusable Wo
 
 利用可能ですが、最終的なテストやフィードバック待ちのバージョンとなります。  
 
+* [calc_next_date.yml](./.github/workflows/calc_next_date.yml)
 * [create_gh_discussion.yml](./.github/workflows/create_gh_discussion.yml)
-* [get_next_scheduled_date.yml](./.github/workflows/get_next_scheduled_date.yml)
 
 ## 開発者向け
 


### PR DESCRIPTION
@TomckySan PR https://github.com/route06/actions/pull/61 への PR です

## 変更概要

* get_next_scheduled_date.yml に `scheduled` というコンテキストは必要ないと感じたので、calc_next_date.yml にリネームしました
    * calc_next_date.yml は「現在の時刻と入力された条件から、次の日付を計算する」という役割に徹する。何に使われるかは知らない。というニュアンスです
    * それにともない、全体的に `scheduled` という文字列を削除しました
* create_gh_discussion.yml の usage は、calc_next_date.yml を使う方法に更新しました

## 動作確認結果

💡 2024/07/31 13:00 JST 頃に動作確認しました

### time_zone: default (Asia/Tokyo, GMT+9) ✅

コード:
https://github.com/masutaka/sandbox/blob/2c3e65603b460d8e60b2a3a4138a6030f70dd74f/.github/workflows/calc_date.yml

結果:
https://github.com/masutaka/sandbox/actions/runs/10173764531/job/28138394137

<img width="473" alt="Asia/Tokyo" src="https://github.com/user-attachments/assets/861e5845-e776-4feb-9318-cbb43abc8752">

### time_zone: Pacific/Gambier, GMT-9 ✅

コード:
https://github.com/masutaka/sandbox/blob/135762e05eeb6fe695054ca18cd8ca95ca8a1f00/.github/workflows/calc_date.yml

結果:
https://github.com/masutaka/sandbox/actions/runs/10173784428/job/28138449726

<img width="483" alt="image" src="https://github.com/user-attachments/assets/88070105-bb31-48a0-aabb-8f3229c7d111">
