### PR TITLE
Improve input name of create_gh_discussion.yml

### DIFF
--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -21,13 +21,13 @@
 #     with:
 #       # NOTE: 作成するDiscussionのタイトルを指定
 #       title: ${{ needs.get_next_meeting_date.outputs.next_date }} Meeting Title
-#       # NOTE: discussion_category_slugについては補足参照
-#       discussion_category_slug: ideas
+#       # NOTE: category_slugについては補足参照
+#       category_slug: ideas
 #       # NOTE: 作成するDiscussionで使用するテンプレートファイルのパスを指定
 #       description_template_path: _templates/weekly_meeting_discussion/test.md
 #
 # 補足:
-# discussion_category_slug は各カテゴリを選択した時の、URL 末尾の文字列です。以下は例です。
+# category_slug は各カテゴリを選択した時の、URL 末尾の文字列です。以下は例です。
 # カテゴリ `Q&A` の slug は `q-a`:
 #   https://github.com/<org>/<repo>/discussions/categories/q-a
 # カテゴリ `Show and tell` の slug は `show-and-tell`:
@@ -42,7 +42,7 @@ on:
         description: 作成するDiscussionのタイトルを設定してください。
         required: true
         type: string
-      discussion_category_slug:
+      category_slug:
         description: 作成するDiscussionのカテゴリslugを設定してください。
         default: general
         type: string
@@ -62,7 +62,7 @@ jobs:
       - name: Run script
         env:
           REPOSITORY: ${{ github.repository }}
-          DISCUSSION_CATEGORY_SLUG: ${{ inputs.discussion_category_slug }}
+          CATEGORY_SLUG: ${{ inputs.category_slug }}
           TITLE: ${{ inputs.title }}
           DESCRIPTION_TEMPLATE_PATH: ${{ inputs.description_template_path }}
         uses: actions/github-script@v7
@@ -102,14 +102,14 @@ jobs:
               });
             }
 
-            const { REPOSITORY, DISCUSSION_CATEGORY_SLUG, TITLE, DESCRIPTION_TEMPLATE_PATH } = process.env;
+            const { REPOSITORY, CATEGORY_SLUG, TITLE, DESCRIPTION_TEMPLATE_PATH } = process.env;
             const [owner, repositoryName] = REPOSITORY.split('/');
 
             const repositoryIdAndCategoryId = await featchRepoIdAndDiscussionCategoryId(
               github,
               owner,
               repositoryName,
-              DISCUSSION_CATEGORY_SLUG,
+              CATEGORY_SLUG,
             )
 
             const discussionTitle = TITLE;


### PR DESCRIPTION
@TomckySan PR https://github.com/route06/actions/pull/61 への PR です

## 変更概要

以下の inputs に対して、category_slug だけ `discussion_` prefix が付いているのは違和感があったので修正しました。

* title
* description_template_path

細かいと言えば細かいですが、リリース後に変更すると破壊的な変更になるため、このタイミングで修正しました。

## 動作確認結果

💡 2024/08/01 13:40 JST 頃に動作確認しました

コード:
https://github.com/masutaka/sandbox/blob/30bf8ea8629e5aef87509f83b161375a9663b23e/.github/workflows/create_discussion.yml

結果:
https://github.com/masutaka/sandbox/actions/runs/10192146455
↓
https://github.com/masutaka/sandbox/discussions/10
