### PR TITLE
全ての workflow に `name:` を設定しつつ、reusable workflow のドキュメントを改善する

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -1,16 +1,25 @@
+# ## Summary
+#
 # PR 作成時に assignee を、PR 作成者に設定する。ただし、以下のケースを除く。
 #   * PR 作成者のユーザータイプが Bot である
 #   * すでに PR 作成時に assignee が設定されている
+
+# ## Usage
 #
-# @usage
+# name: Add assignee to PR
+#
 # on:
 #   pull_request:
 #     types: [opened]
+#
 # jobs:
 #   add-assignee-to-pr:
 #     permissions:
 #       pull-requests: write
 #     uses: route06/actions/.github/workflows/add_assignee_to_pr.yml@v2
+
+name: Add assignee to PR
+
 on:
   workflow_call:
 

--- a/.github/workflows/calc_next_date.yml
+++ b/.github/workflows/calc_next_date.yml
@@ -1,4 +1,8 @@
-# @usage
+# ## Summary
+#
+# Calculates a next date from the given arguments.
+
+# ## Usage
 #
 # name: Calc next date
 #

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,18 @@
+# ## Summary
+#
 # 変更されたファイルの拡張子をチェックし、結果に応じた言語のCodeQLワークフローを呼び出す
 
-# 作成の背景：
+# ## Background
+#
 # ROUTE06では元々Code Scanningのデフォルト設定を使用していたが、
 # 運用のなかで以下のような課題が見つかるようになった。
 # ・ドキュメントのみの修正にも関わらず、すべてのプログラミング言語用のジョブが動く
 # ・解析しなくてよいディレクトリ配下の指摘が多数見つかる
 # 前述の課題を解決すべくデフォルト設定を使用せず、自前でワークフローを定義している。
 
-# @usage
-# name: CodeQL
+# ## Usage
+#
+# name: Run CodeQL
 #
 # on:
 #   push:
@@ -23,7 +27,8 @@
 #   codeql:
 #     uses: route06/actions/.github/workflows/codeql.yml@v2
 
-# 使用上の注意：
+# ## Usage note
+#
 # マージキューを活用しているリポジトリでは、
 # ジョブの実行ブランチが下記の命名規則に沿ったブランチになることがある
 # gh-readonly-queue/{base_branch}/pr-{pr_num}-{base_branch_hash}

--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -1,5 +1,12 @@
-# CodeQLを実行するワークフロー
-# .github/workflows/codeql.ymlから呼び出される
+# ## Summary
+#
+# The core workflow of CodeQL which called by .github/workflows/codeql.yml
+
+# ## Usage
+#
+# None.
+
+name: Run CodeQL Core
 
 on:
   workflow_call:

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -1,6 +1,10 @@
-# @usage
+# ## Summary
 #
-# name: Create GitHub discussion
+# Create GitHub Discussion from the given arguments.
+
+# ## Usage
+#
+# name: Create GitHub Discussion
 #
 # on:
 #   schedule:
@@ -24,15 +28,16 @@
 #       category_slug: ideas
 #       # NOTE: 作成するDiscussionで使用するテンプレートファイルのパスを指定
 #       description_template_path: _templates/weekly_meeting_discussion/test.md
+
+# ## Note
 #
-# 補足:
 # category_slug は各カテゴリを選択した時の、URL 末尾の文字列です。以下は例です。
 # カテゴリ `Q&A` の slug は `q-a`:
 #   https://github.com/<org>/<repo>/discussions/categories/q-a
 # カテゴリ `Show and tell` の slug は `show-and-tell`:
 #   https://github.com/<org>/<repo>/discussions/categories/show-and-tell
 
-name: Create GitHub discussion
+name: Create GitHub Discussion
 
 on:
   workflow_call:

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -1,4 +1,3 @@
-# todo: 以下はStarter Workflow化する
 # @usage
 #
 # name: Create GitHub discussion

--- a/.github/workflows/get_last_discussion_url.yml
+++ b/.github/workflows/get_last_discussion_url.yml
@@ -1,6 +1,10 @@
-# 指定した "repo" で、タイトル名に "title" が含まれる最新の Discussion URL を返す。
+# ## Summary
 #
-# @usage
+# 指定した "repo" で、タイトル名に "title" が含まれる最新の Discussion URL を返す。
+
+# ## Usage
+#
+# name: Get last GitHub Discussion URL
 #
 # jobs:
 #   get-last-discussion-url:
@@ -16,7 +20,9 @@
 #     runs-on: ubuntu-latest
 #     steps:
 #       - run: echo ${{ needs.get-last-discussion-url.outputs.url }}
-#
+
+name: Get last GitHub Discussion URL
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/gh_discussion_comment_to_slack.yml
+++ b/.github/workflows/gh_discussion_comment_to_slack.yml
@@ -1,19 +1,31 @@
-# Github Discussionのコメントが投稿された際に、内容をSlackに送信します。
-# NOTE: 現在GitHubのSlack連携ではコメント通知をサポートしていません。
-# @see: [Get notifications for comment/reply of Discussions in slack (or equivalent) · community · Discussion #56821](https://github.com/orgs/community/discussions/56821)
+# ## Summary
 #
-# @usage
+# Github Discussionのコメントが投稿された際に、内容をSlackに送信します。
+
+# ## Background
+#
+# 現在GitHubのSlack連携ではコメント通知をサポートしていません。
+#
+# Get notifications for comment/reply of Discussions in slack (or equivalent)
+# https://github.com/orgs/community/discussions/56821
+
+# ## Usage
+#
+# name: Post GitHub Discussion comment to Slack
 #
 # on:
 #   discussion_comment:
 #     types: [created]
+#
 # jobs:
 #   discussion_commented:
 #     if: github.event.discussion && github.event.comment
 #     uses: route06/actions/.github/workflows/gh_discussion_comment_to_slack.yml@v2
 #     secrets:
-#       slack-webhook-url: ${{ secrets.SLACK_XXX_WEBHOOK_URL }}
-#
+#       slack-webhook-url: ${{ secrets.SLACK_XXX_WEBHOOK_URL }} # Set this secret
+
+name: Post GitHub Discussion comment to Slack
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: My Release
 
 on:
   push:

--- a/.github/workflows/my_setup_pr.yml
+++ b/.github/workflows/my_setup_pr.yml
@@ -1,4 +1,4 @@
-name: Setup PR
+name: My Setup PR
 
 on:
   pull_request:

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: My Test
 
 on:
   pull_request:

--- a/.github/workflows/notify_slack_on_ci_failed.yml
+++ b/.github/workflows/notify_slack_on_ci_failed.yml
@@ -1,6 +1,10 @@
-# "SLACK_WEBHOOK_URL" に紐づく channel に、CI 失敗時用の Slack 通知をする。"title" を設定可能。
+# ## Summary
 #
-# @usage
+# "SLACK_XXX_WEBHOOK_URL" に紐づく channel に、CI 失敗時用の Slack 通知をする。
+
+# ## Usage
+#
+# name: Notify to Slack on CI failure
 #
 # jobs:
 #   notify:
@@ -8,7 +12,10 @@
 #     with:
 #       title: CI failed / ci.yml
 #     secrets:
-#       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_XXX_WEBHOOK_URL }}
+#       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_XXX_WEBHOOK_URL }} # Set this secret
+
+name: Notify to Slack on CI failure
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## 変更概要

(1) 見栄えが良くないので、全ての workflow に `name:` を設定しました。また、`my_*.yml` の workflow は `My ` prefix を付けました（[参考](https://github.com/route06/actions/blob/v2.2.0/docs/adr/003-%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E3%81%AE%E5%91%BD%E5%90%8D%E8%A6%8F%E5%89%87.md)）。

🔗 https://github.com/route06/actions/actions

<img width="332" alt="My Workflows" src="https://github.com/user-attachments/assets/be3160b9-e1ca-4201-957f-db79a3ddc7e8">

(2) ドキュメント中の usage にも `name:` を設定し、見栄えの悪さがユーザーに伝播しないようにしました。

(3) 全体的にドキュメントを改善しました。

## レビュー方法

f47f04dbdcd84adc52ab9c68c9d32e513c006135 以外は、変更後のファイルを確認するとレビューしやすいかと思います。

* [add_assignee_to_pr.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/add_assignee_to_pr.yml)
* [calc_next_date.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/calc_next_date.yml)
* [codeql.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/codeql.yml)
* [codeql_core.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/codeql_core.yml)
* [create_gh_discussion.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/create_gh_discussion.yml)
* [get_last_discussion_url.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/get_last_discussion_url.yml)
* [gh_discussion_comment_to_slack.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/gh_discussion_comment_to_slack.yml)
* [notify_slack_on_ci_failed.yml](https://github.com/route06/actions/blob/add-name-to-workflows/.github/workflows/notify_slack_on_ci_failed.yml)

## やらなかったこと

my_test.yml に以下のテストを導入し、(1)(2) が壊れた時に気付けるようにしたらどうだろう？と思いました。しかし、維持コストに見合わないと感じて止めました。

<details><summary>Details</summary>

```patch
diff --git a/.github/workflows/my_test.yml b/.github/workflows/my_test.yml
index dfdb203..b4fc7c7 100644
--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -32,3 +32,72 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ls-lint/action@1887e6c0e7f2dfa81a2d67591f0eb7782720026f # v2.2.3
+
+  own-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+        working-directory: .github/workflows
+    steps:
+      - uses: actions/checkout@v4
+      - name: "List workflows missing '^name:' line"
+        run: |
+          REGEXP='^name:'
+          missing_files=()
+
+          for file in *.yml; do
+            if ! grep -lq "$REGEXP" $file; then
+              missing_files+=("$file")
+            fi
+          done
+
+          if [ "${#missing_files[@]}" = 0 ]; then
+            echo "All workflows contain the '$REGEXP' line."
+            exit 0
+          fi
+
+          echo "The following workflows are missing the '$REGEXP' line:"
+          for file in "${missing_files[@]}"; do
+            echo "$file"
+          done
+
+          exit 1
+
+      - name: "List workflows missing '^# name:' line"
+        run: |
+          REGEXP='^# name:'
+
+          IGNORE_FILES=(
+            "codeql_core.yml"
+            "my_*.yml"
+          )
+
+          missing_files=()
+
+          for file in *.yml; do
+            # Skip ignored files
+            for ignore in "${IGNORE_FILES[@]}"; do
+              if [[ "$file" == $ignore ]]; then
+                echo "ignore: $file"
+                continue 2
+              fi
+            done
+
+            if ! grep -lq "$REGEXP" $file; then
+              missing_files+=("$file")
+            fi
+          done
+
+          if [ "${#missing_files[@]}" = 0 ]; then
+            echo "All workflows contain the '$REGEXP' line."
+            exit 0
+          fi
+
+          echo "The following workflows are missing the '$REGEXP' line:"
+          for file in "${missing_files[@]}"; do
+            echo "$file"
+          done
+
+          exit 1
```

</details>
