### PR TITLE
GitHub Issue を作成する reusable workflow を作成する

### DIFF
--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -42,44 +42,19 @@ on:
       labels:
         description: "（任意）Issue の Labels; 例: bug, wontfix"
         type: string
-    outputs:
-      number:
-        description: "作成された Issue Number"
-        value: ${{ jobs.create_issue.outputs.number }}
-      url:
-        description: "作成された Issue URL"
-        value: ${{ jobs.create_issue.outputs.url }}
 
 jobs:
   create_issue:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      LABELS: "${{ inputs.labels }}"
     steps:
       - uses: actions/checkout@v4
-      - name: Decide template filename
+      - name: Create a issue
         run: |
-          echo "TEMPLATE_WITH_HEADER=template_work$$.md" >> "$GITHUB_ENV"
-      - name: Setup issue template
-        run: |
-          echo ""
-
-          cat <<EOF > ${{ env.TEMPLATE_WITH_HEADER }}
-          ---
-          title: "${{ inputs.title }}"
-          assignees: "${{ inputs.assignees }}"
-          labels: "${{ inputs.labels }}"
-          ---
-
-          $(cat ${{ inputs.description_template_path }})
-          EOF
-      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
-        id: create_an_issue
+          gh issue create \
+            --title '${{ inputs.title }}' \
+            --body "$(cat ${{ inputs.description_template_path }})" \
+            --assignee '${{ inputs.assignees }}' \
+            --label '${{ inputs.labels }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: ${{ env.TEMPLATE_WITH_HEADER }}
-    outputs:
-      number: ${{ steps.create_an_issue.outputs.number }}
-      url: ${{ steps.create_an_issue.outputs.url }}

--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -1,0 +1,85 @@
+# ## Summary
+#
+# Create GitHub Issue from the given arguments.
+
+# ## Usage
+#
+# name: Create GitHub Issue
+#
+# on:
+#   schedule:
+#     # 毎週水曜 13:00 JST に実行
+#     - cron: "0 4 * * wed"
+#
+# jobs:
+#   create_discussion:
+#     uses: route06/actions/.github/workflows/create_gh_issue.yml@v2
+#     permissions:
+#       contents: read
+#       issues: write
+#     with:
+#       title: Sample Issue
+#       description_template_path: _templates/sample_issue.md
+#       assignees: alice, bob
+#       labels: bug, wontfix
+
+name: Create GitHub Issue
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        description: "作成する Issue のタイトル"
+        required: true
+        type: string
+      description_template_path:
+        description: "Issue の説明に利用するテンプレートファイルのパス"
+        required: true
+        type: string
+      assignees:
+        description: "（任意）Issue の Assignees; 例: alice, bob"
+        type: string
+      labels:
+        description: "（任意）Issue の Labels; 例: bug, wontfix"
+        type: string
+    outputs:
+      number:
+        description: "作成された Issue Number"
+        value: ${{ jobs.create_issue.outputs.number }}
+      url:
+        description: "作成された Issue URL"
+        value: ${{ jobs.create_issue.outputs.url }}
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      LABELS: "${{ inputs.labels }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Decide template filename
+        run: |
+          echo "TEMPLATE_WITH_HEADER=template_work$$.md" >> "$GITHUB_ENV"
+      - name: Setup issue template
+        run: |
+          echo ""
+
+          cat <<EOF > ${{ env.TEMPLATE_WITH_HEADER }}
+          ---
+          title: "${{ inputs.title }}"
+          assignees: "${{ inputs.assignees }}"
+          labels: "${{ inputs.labels }}"
+          ---
+
+          $(cat ${{ inputs.description_template_path }})
+          EOF
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        id: create_an_issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: ${{ env.TEMPLATE_WITH_HEADER }}
+    outputs:
+      number: ${{ steps.create_an_issue.outputs.number }}
+      url: ${{ steps.create_an_issue.outputs.url }}

--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -12,7 +12,7 @@
 #     - cron: "0 4 * * wed"
 #
 # jobs:
-#   create_discussion:
+#   create_issue:
 #     uses: route06/actions/.github/workflows/create_gh_issue.yml@v2
 #     permissions:
 #       contents: read


### PR DESCRIPTION
## 変更概要

* GitHub Issue を生成する reusable workflow を作成した
* title, description_template_path, assignees, labels を入力可能

## 動作確認

* サンプルコード
    * https://github.com/masutaka/sandbox/blob/a9f91dd6d9b4611455b9a1bb230f6bf2d5db46d1/.github/workflows/create_issue.yml
* サンプルコードから指定したテンプレート
    * https://github.com/masutaka/sandbox/blob/a9f91dd6d9b4611455b9a1bb230f6bf2d5db46d1/.github/workflows/templates/issue.md
* 実行した GitHub Action
    * https://github.com/masutaka/sandbox/actions/runs/10842696875
* 作成された GitHub Issue
    * https://github.com/masutaka/sandbox/issues/65

## 備考

当初 5dc94d143fa4f04c7b292742314030d882b5ec95 は [JasonEtco/create-an-issue](https://github.com/JasonEtco/create-an-issue) Action を使いましたが、よく考えたら gh CLI で十分だったので、 0b60a3786bc3cdfa6af0831530e3b2bbfcbe526a でリファクタリングしました。

JasonEtco/create-an-issue はテンプレート中で、環境変数や変数を使えることがメリットですが（下記参照）、一旦シンプルな実装にしました。

🔗 https://github.com/JasonEtco/create-an-issue/tree/56fdd2d6f960e970fa9d5ca3cf3884b6ba5af477?tab=readme-ov-file#usage

> You'll notice that the above example has some `{{ mustache }}` variables. Your issue templates have access to several things about the event that triggered the action. Besides `issue` and `pullRequest`, you have access to all the template variables [on this list](https://github.com/JasonEtco/actions-toolkit#toolscontext). You can also use environment variables:
