### PR TITLE
Fix the usage of create_gh_issue.yml

### DIFF
--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -20,8 +20,8 @@
 #     with:
 #       title: Sample Issue
 #       description_template_path: _templates/sample_issue.md
-#       assignees: alice, bob
-#       labels: bug, wontfix
+#       assignees: alice,bob
+#       labels: bug,wontfix
 
 name: Create GitHub Issue
 
@@ -37,10 +37,10 @@ on:
         required: true
         type: string
       assignees:
-        description: "（任意）Issue の Assignees; 例: alice, bob"
+        description: "（任意）Issue の Assignees; 例: alice,bob"
         type: string
       labels:
-        description: "（任意）Issue の Labels; 例: bug, wontfix"
+        description: "（任意）Issue の Labels; 例: bug,wontfix"
         type: string
 
 jobs:


### PR DESCRIPTION
https://github.com/route06/actions/pull/73 の軽い修正です。

複数の `assignees` と `labels` の指定に誤りがありました。`,` の後ろにスペースを付けてはいけない。

```
$ gh issue create --title '2024/09/13 Sample TODO' --body "Hoge" --assignee 'masutaka' --label 'bug, wontfix'

Creating issue in masutaka/sandbox

could not add label: ' wontfix' not found
```

ヘルプもそう表記されていました。

```
$ gh issue create --help
(snip)
  $ gh issue create --label "bug,help wanted"
  $ gh issue create --label bug --label "help wanted"
  $ gh issue create --assignee monalisa,hubot
(snip)
```
