### PR TITLE
Add workflow_dispatch to My Release workflow

### DIFF
--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -1,6 +1,7 @@
 name: My Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ npm run adr:new タイトル
     * 例: https://github.com/route06/actions/pull/21
 1. デフォルトではパッチバージョンが 1 つ上がります
     * メジャーバージョンを上げたい時は `tagpr:major` ラベルを、マイナーバージョンを上げたい時は `tagpr:minor` ラベルを付けて下さい
+    * Release 対象の PR が全部揃った後に、リリースの種類をパッチからマイナー等に変更したい場合は、ラベルを付けてから [My Release](https://github.com/route06/actions/actions/workflows/my_release.yml) ワークフローを実行して下さい。ブランチは main から変えないで下さい
 1. マージすると [Releases](https://github.com/route06/actions/releases) に、新しいバージョンのリリースが作られます
     * 加えて、v2 などのタグが最新の v2.Y.Z を指すように、git tag が書き換えられます


### PR DESCRIPTION
## 背景

🔗 https://github.com/route06/actions/pull/66#issuecomment-2290749710

> 後から `tagpr:minor` タグをつけたため、CHANGELOGが2.2.1のままとなっている
PRのclose/reopenではtagpr jobは実行されないのか

> mainブランチへのpush jobを再実行することで再度tagpr jobを動かしてみる
>
> https://github.com/route06/actions/actions/runs/10397457019

リリース対象の PR が揃ったあとに、リリースの種類を変えるのが分かりづらかった。

## 変更内容

[My Release](https://github.com/route06/actions/actions/workflows/my_release.yml) ワークフローを手動実行できるようにした。
