### PR TITLE
Refactor .github/workflows/create_gh_issue.yml

### DIFF
--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           gh issue create \
             --title '${{ inputs.title }}' \
-            --body "$(cat ${{ inputs.description_template_path }})" \
+            --body-file '${{ inputs.description_template_path }}' \
             --assignee '${{ inputs.assignees }}' \
             --label '${{ inputs.labels }}'
         env:


### PR DESCRIPTION
https://github.com/route06/actions/pull/73 の改善です。

## 変更概要

gh issue create には `--body-file` オプションがあったことに気がついたので、`--body` + `cat` から変更しました。

## 動作確認

* サンプルコード
    * https://github.com/masutaka/sandbox/blob/a3876601dbaf0071ed5b381ad16b1e2d1127f599/.github/workflows/create_issue.yml
* 実行した GitHub Action
    * https://github.com/masutaka/sandbox/actions/runs/10846316799
* 作成された GitHub Issue
    * https://github.com/masutaka/sandbox/issues/70

## 参考

https://cli.github.com/manual/gh_issue_create
