### PR TITLE
Dynamically generate CodeQL jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,8 +57,9 @@ jobs:
 
       # GitHub Actions組み込みのpathsによるフィルタでは、そのymlで実行する複数のjobそれぞれでpathsによる分岐ができない
       # そのため https://github.com/dorny/paths-filter を使い、フィルタのjob → 各jobの順で実行することで複数jobの分岐を実現する
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
+      - name: Determine languages
+        id: determine
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           # ここで指定したkeyがoutputsに出力される
           #
@@ -116,12 +117,12 @@ jobs:
         with:
           script: |
             const outputs = {
-              go: ${{ steps.filter.outputs.go }},
-              java: ${{ steps.filter.outputs.java }},
-              javascript: ${{ steps.filter.outputs.javascript }},
-              python: ${{ steps.filter.outputs.python }},
-              ruby: ${{ steps.filter.outputs.ruby }},
-              swift: ${{ steps.filter.outputs.swift }},
+              go: ${{ steps.determine.outputs.go }},
+              java: ${{ steps.determine.outputs.java }},
+              javascript: ${{ steps.determine.outputs.javascript }},
+              python: ${{ steps.determine.outputs.python }},
+              ruby: ${{ steps.determine.outputs.ruby }},
+              swift: ${{ steps.determine.outputs.swift }},
             };
 
             const languages = Object.keys(outputs)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
-      languages: ${{ steps.formatted_filters.outputs.languages }}
+      languages: ${{ steps.format.outputs.languages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,18 +110,24 @@ jobs:
               - added|modified: '**/*.plist'
               - added|modified: '**/*.storyboard'
               - added|modified: '**/*.xib'
-      - name: format filters result
-        id: formatted_filters
-        run: |
-          languages="["
-          [[ ${{ steps.filter.outputs.go }} == true ]] && languages+='"go",'
-          [[ ${{ steps.filter.outputs.javascript }} == true ]] && languages+='"javascript",'
-          [[ ${{ steps.filter.outputs.python }} == true ]] && languages+='"python",'
-          [[ ${{ steps.filter.outputs.ruby }} == true ]] && languages+='"ruby",'
-          [[ ${{ steps.filter.outputs.java }} == true ]] && languages+='"java,'
-          [[ ${{ steps.filter.outputs.swift }} == true ]] && languages+='"swift,'
-          languages="${languages%,}]"
-          echo "languages=$languages" >> "$GITHUB_OUTPUT"
+      - name: Format filtered languages
+        id: format
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const outputs = {
+              go: ${{ steps.filter.outputs.go }},
+              javascript: ${{ steps.filter.outputs.javascript }},
+              python: ${{ steps.filter.outputs.python }},
+              ruby: ${{ steps.filter.outputs.ruby }},
+              java: ${{ steps.filter.outputs.java }},
+              swift: ${{ steps.filter.outputs.swift }},
+            };
+
+            const languages = Object.keys(outputs)
+              .filter(lang => outputs[lang]);
+
+            core.setOutput('languages', JSON.stringify(languages));
 
   languages:
     needs: changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,6 +71,10 @@ jobs:
           filters: |
             go:
               - added|modified: '**/*.go'
+            java:
+              - added|modified: '**/*.kt'
+              - added|modified: '**/*.kts'
+              - added|modified: '**/*.ktm'
             javascript:
               - added|modified: '**/*.js'
               - added|modified: '**/*.jsx'
@@ -101,10 +105,6 @@ jobs:
               - added|modified: '**/*.erb'
               - added|modified: '**/*.gemspec'
               - added|modified: '**/Gemfile'
-            java:
-              - added|modified: '**/*.kt'
-              - added|modified: '**/*.kts'
-              - added|modified: '**/*.ktm'
             swift:
               - added|modified: '**/*.swift'
               - added|modified: '**/*.plist'
@@ -117,10 +117,10 @@ jobs:
           script: |
             const outputs = {
               go: ${{ steps.filter.outputs.go }},
+              java: ${{ steps.filter.outputs.java }},
               javascript: ${{ steps.filter.outputs.javascript }},
               python: ${{ steps.filter.outputs.python }},
               ruby: ${{ steps.filter.outputs.ruby }},
-              java: ${{ steps.filter.outputs.java }},
               swift: ${{ steps.filter.outputs.swift }},
             };
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,12 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
-      go: ${{ steps.filter.outputs.go }}
-      javascript: ${{ steps.filter.outputs.javascript }}
-      python: ${{ steps.filter.outputs.python }}
-      ruby: ${{ steps.filter.outputs.ruby }}
-      java: ${{ steps.filter.outputs.java }}
-      swift: ${{ steps.filter.outputs.swift }}
+      languages: ${{ steps.formatted_filters.outputs.languages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -115,45 +110,26 @@ jobs:
               - added|modified: '**/*.plist'
               - added|modified: '**/*.storyboard'
               - added|modified: '**/*.xib'
+      - name: format filters result
+        id: formatted_filters
+        run: |
+          languages="["
+          [[ ${{ steps.filter.outputs.go }} == true ]] && languages+='"go",'
+          [[ ${{ steps.filter.outputs.javascript }} == true ]] && languages+='"javascript",'
+          [[ ${{ steps.filter.outputs.python }} == true ]] && languages+='"python",'
+          [[ ${{ steps.filter.outputs.ruby }} == true ]] && languages+='"ruby",'
+          [[ ${{ steps.filter.outputs.java }} == true ]] && languages+='"java,'
+          [[ ${{ steps.filter.outputs.swift }} == true ]] && languages+='"swift,'
+          languages="${languages%,}]"
+          echo "languages=$languages" >> "$GITHUB_OUTPUT"
 
-  go:
+  languages:
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' }}
+    if: ${{ needs.changes.outputs.languages != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJson(needs.changes.outputs.languages) }}
     uses: ./.github/workflows/codeql_core.yml
     with:
-      language: "go"
-
-  javascript:
-    needs: changes
-    if: ${{ needs.changes.outputs.javascript == 'true' }}
-    uses: ./.github/workflows/codeql_core.yml
-    with:
-      language: "javascript"
-
-  python:
-    needs: changes
-    if: ${{ needs.changes.outputs.python == 'true' }}
-    uses: ./.github/workflows/codeql_core.yml
-    with:
-      language: "python"
-
-  ruby:
-    needs: changes
-    if: ${{ needs.changes.outputs.ruby == 'true' }}
-    uses: ./.github/workflows/codeql_core.yml
-    with:
-      language: "ruby"
-
-  java:
-    needs: changes
-    if: ${{ needs.changes.outputs.java == 'true' }}
-    uses: ./.github/workflows/codeql_core.yml
-    with:
-      language: "java"
-
-  swift:
-    needs: changes
-    if: ${{ needs.changes.outputs.swift == 'true' }}
-    uses: ./.github/workflows/codeql_core.yml
-    with:
-      language: "swift"
+      language: ${{ matrix.language }}

--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   analyze:
-    name: Perform CodeQL
+    name: Perform CodeQL for ${{ inputs.language }}
     runs-on: ${{ (inputs.language == 'swift' && 'macos-latest') || 'ubuntu-22.04'  }}
     timeout-minutes: 30
 


### PR DESCRIPTION
## 変更概要

今までは CodeQL ジョブが最大 6 個 skip され、PR ステータスを占有していました。

本 PR では実際に実行された CodeQL ジョブだけ、PR ステータスに表示されます。ただし、CodeQL ジョブが実行されなかった場合、skip ジョブが 1 つだけ表示されます。後述の「動作確認結果」をご覧下さい。

他に step 名と job 名を改善しました。commit を 1 つずつ読むと分かるかと思います。

## 動作確認結果

https://github.com/masutaka/sandbox/pull/80 で動作確認した。

### language 数 0

* Filter Paths ジョブが実行され、Perform CodeQL for ... ジョブは 1 個も実行されず skip される
    * https://github.com/masutaka/sandbox/actions/runs/11046157812
* PR 上での見え方

    <img width="800" alt="language 数 0" src="https://github.com/user-attachments/assets/d22f4b05-dd0c-4077-8669-d8c24673ed91">

### language 数 1

* Filter Paths ジョブが実行され、Perform CodeQL for ... ジョブは 1 個実行される
    * https://github.com/masutaka/sandbox/actions/runs/11046170531/attempts/1
* PR 上での見え方

    <img width="800" alt="language 数 1" src="https://github.com/user-attachments/assets/6573cae8-2f0e-4e49-a8c1-ad7ef833b4e9">

### language 数 4

* Filter Paths ジョブが実行され、Perform CodeQL for ... ジョブは 4 個実行される。1 つ失敗しているのは無視して大丈夫
    * https://github.com/masutaka/sandbox/actions/runs/11046199493
* PR 上での見え方

    <img width="800" alt="language 数 4" src="https://github.com/user-attachments/assets/397c4c21-0b5e-49a5-b54f-1c92eaa71b13">

### language 数 6 (max)

* Filter Paths ジョブが実行され、Perform CodeQL for ... ジョブは最大の 6 個実行される。2 つ失敗しているのは無視して大丈夫
    * https://github.com/masutaka/sandbox/actions/runs/11046237952
* PR 上での見え方

    <img width="800" alt="language 数 6 (max)" src="https://github.com/user-attachments/assets/53c2e32e-26f9-44c0-8522-0e9cd6ab1091">

