### PR TITLE
Always use ubuntu-latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   changes:
     name: Filter Paths
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       languages: ${{ steps.format.outputs.languages }}

--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze:
     name: Perform CodeQL for ${{ inputs.language }}
-    runs-on: ${{ (inputs.language == 'swift' && 'macos-latest') || 'ubuntu-22.04'  }}
+    runs-on: ${{ (inputs.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## 概要

CodeQL 関連 workflow だけ、ubuntu-22.04 を使っている。他の reusable workflow は全て ubuntu-latest。

* https://github.com/route06/actions/blob/v2.4.1/.github/workflows/codeql.yml#L50
* https://github.com/route06/actions/blob/v2.4.1/.github/workflows/codeql_core.yml#L21

Ubuntu のバージョンを固定して、セキュリティや信頼性を高めようとしたのだと思う。

経験上、GitHub Actions で Ubuntu バージョンを固定しなくて壊れたことはないし、自動アップデートの仕組みもないと思うので、ubuntu-latest に変更する。

## 動作確認

大丈夫そうです。
https://github.com/masutaka/sandbox/actions/runs/11101601135

## 参考

現在の ubuntu-latest は ubuntu-24.04 へのエイリアス。
https://github.com/actions/runner-images/tree/ce5aa1950d31fd67c0014160a0164005a3e7f43c

ubuntu-22.04 の End of Standard Support は 2027/04。
https://ubuntu.com/about/release-cycle
