### PR TITLE
Reduce the frequency of Dependabot update for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "10:00"
       timezone: "Asia/Tokyo"
   - package-ecosystem: "npm"


### PR DESCRIPTION
これまで続けてきて、毎週アップデートはしなくて良い気がしたので、毎月アップデートに頻度を下げました。

See also:
https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
