### PR TITLE
Dependency Review ジョブが失敗したら、PR にコメントする

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -8,6 +8,10 @@
 #
 # on: [pull_request]
 #
+# permissions:
+#   contents: read
+#   pull-requests: write
+#
 # jobs:
 #   dependency_review:
 #     uses: route06/actions/.github/workflows/dependency_review.yml@v2
@@ -20,13 +24,19 @@ name: Dependency Review
 
 on:
   workflow_call:
+    inputs:
+      comment-summary-in-pr:
+        description: Determines if the summary is posted as a comment in the PR itself. Setting this to `always` or `on-failure` requires you to give the workflow the write permissions for pull-requests
+        default: on-failure
+        required: false
+        type: string
 
 jobs:
   dependency_review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}


### PR DESCRIPTION
## 変更概要

.github/workflows/dependency_review.yml デフォルトで、PR にコメントするようにしました。

そのためにはユーザー側で permissions を設定する必要があるため、破壊的な変更とは言えないまでも、近い変更にはなっています。

## 背景

Dependency Review ジョブが失敗すると CI が落ちるので気づくことはできます。

ただ、"▶Vulnerabilities" をクリックしないと分かりません。

🔗 https://github.com/masutaka/sandbox/actions/runs/13430473078/job/37521109378

<img width="787" alt="Job status" src="https://github.com/user-attachments/assets/336ac54d-203a-43ce-87de-a6c858e950e2" />

一方で Summary をクリックすると分かりやすい結果を確認できることは、気づくのが難しいです。

🔗 https://github.com/masutaka/sandbox/actions/runs/13430473078

<img width="1144" alt="Workflow summary" src="https://github.com/user-attachments/assets/f7bbdcdd-1c54-4f14-939b-623bf34416d6" />

別な話として、巨大な PR では脆弱性が見つかる以外で Dependency Review ジョブが失敗することがあります。

* https://github.com/actions/dependency-review-action/issues/786
* https://github.com/actions/dependency-review-action/issues/867

## 参考

こんな振る舞いだった。

1. 当該 PR で脆弱性が初めて見つかる
    * Dependency Review の CI が失敗し、PR にコメントが追加される
    * 例: https://github.com/masutaka/sandbox/pull/104#issuecomment-2670769586
2. PR に commit を追加した。脆弱性は修正されていない
    * Dependency Review の CI が失敗し、`1` のコメントが編集される
3. PR に commit を追加した。脆弱性が修正された
    * Dependency Review の CI が成功する。`1` のコメントはそのまま

当該コードはこのあたり。
https://github.com/actions/dependency-review-action/blob/v4.5.0/src/comment-pr.ts#L41-L58
