### PR TITLE
Add cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "monthly"
       time: "10:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -15,3 +17,5 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 概要
Dependabot のバージョン更新に cooldown 期間を設定し、セキュリティ上のリスクを軽減します。

## 背景
[npmパッケージ/GitHub Actionsを利用する側/公開する側でサプライチェーン攻撃を防ぐためにやることメモ](https://zenn.dev/azu/articles/ad168118524135) に記載されているように、リリース直後のパッケージには悪意のあるコードが含まれる可能性があります。

## 変更内容
- GitHub Actions と npm の両方の package ecosystem に `cooldown.default-days: 7` を追加
- パッケージのリリースから 7 日間は自動更新を待機
- この期間中に問題が発見されれば、悪意のあるバージョンを回避できる

## 影響
- セキュリティリスクの軽減
- 更新頻度がわずかに低下するが、月次/週次の更新スケジュールには大きな影響なし
- より安定したパッケージバージョンの採用

## 参考
- [Dependabot options reference - cooldown](https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown)