### PR TITLE
pin GitHub Actions to full-length commit SHA

### DIFF
--- a/.github/workflows/add_discussion_comment.yml
+++ b/.github/workflows/add_discussion_comment.yml
@@ -81,14 +81,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Add Comment
         id: add_comment
         env:
           DISCUSSION_ID: ${{ inputs.discussion_id }}
           COMMENT_TEMPLATE_PATH: ${{ inputs.comment_template_path }}
           REPLY_TO_COMMENT_ID: ${{ inputs.reply_to_comment_id }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
       languages: ${{ steps.format.outputs.languages }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # GitHub Actions組み込みのpathsによるフィルタでは、そのymlで実行する複数のjobそれぞれでpathsによる分岐ができない
       # そのため https://github.com/dorny/paths-filter を使い、フィルタのjob → 各jobの順で実行することで複数jobの分岐を実現する
@@ -123,7 +123,7 @@ jobs:
               - added|modified: '**/*.xib'
       - name: Format filtered languages
         id: format
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const outputs = {

--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -23,26 +23,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # TODO: CodeQL が動作しないため暫定対応
       # 理想は inputs に java-version を持たせ引数にする
       - name: Set up JDK 17
         if: ${{ inputs.language == 'java' }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: '17'
           distribution: 'corretto'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ inputs.language }}
 
       # コンパイルされた言語を解析するために必要
       # コンパイルされていない言語の場合は直ちに正常終了する
       - name: Auto build
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run script
         id: create_discussion
@@ -74,7 +74,7 @@ jobs:
           CATEGORY_SLUG: ${{ inputs.category_slug }}
           TITLE: ${{ inputs.title }}
           DESCRIPTION_TEMPLATE_PATH: ${{ inputs.description_template_path }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Create a issue
         run: |
           gh issue create \

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}

--- a/.github/workflows/my_release.yml
+++ b/.github/workflows/my_release.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_CI_APP_ID }}
           private-key: ${{ secrets.ACTIONS_CI_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: tagpr
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-tags: true
       - name: Git config

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -13,5 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ls-lint/action@02e380fe8733d499cbfc9e22276de5085508a5bd # v2.3.1


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to full-length commit SHAs
- Preparation for enabling Enforce SHA pinning policy as a supply chain attack countermeasure

🤖 Generated with [Claude Code](https://claude.com/claude-code)