### PR TITLE
fix: remove deprecated node16/node20 actions from reusable workflows

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -34,4 +34,9 @@ jobs:
     if: ${{ github.event.pull_request.user.type != 'Bot' && toJSON(github.event.pull_request.assignees) == '[]' }}
 
     steps:
-      - uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160 # v1.6.2
+      - name: Add the author as an assignee
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: gh pr edit "$PR_URL" --add-assignee "$AUTHOR"

--- a/.github/workflows/add_discussion_comment.yml
+++ b/.github/workflows/add_discussion_comment.yml
@@ -88,7 +88,7 @@ jobs:
           DISCUSSION_ID: ${{ inputs.discussion_id }}
           COMMENT_TEMPLATE_PATH: ${{ inputs.comment_template_path }}
           REPLY_TO_COMMENT_ID: ${{ inputs.reply_to_comment_id }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,11 +100,7 @@ jobs:
               - added|modified: '**/*.hbs'
               - added|modified: '**/*.ejs'
               - added|modified: '**/*.njk'
-              - added|modified: '**/*.json'
-              - added|modified: '**/*.yaml'
-              - added|modified: '**/*.yml'
               - added|modified: '**/*.raml'
-              - added|modified: '**/*.xml'
               - added|modified: '**/*.ts'
               - added|modified: '**/*.tsx'
               - added|modified: '**/*.mts'
@@ -123,7 +119,7 @@ jobs:
               - added|modified: '**/*.xib'
       - name: Format filtered languages
         id: format
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const outputs = {

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -74,7 +74,7 @@ jobs:
           CATEGORY_SLUG: ${{ inputs.category_slug }}
           TITLE: ${{ inputs.title }}
           DESCRIPTION_TEMPLATE_PATH: ${{ inputs.description_template_path }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/get_last_discussion_url.yml
+++ b/.github/workflows/get_last_discussion_url.yml
@@ -49,25 +49,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      url: ${{ fromJSON(steps.get_last_discussion.outputs.data).search.nodes[0].url }}
+      url: ${{ steps.get_last_discussion.outputs.url }}
 
     steps:
       - id: get_last_discussion
         name: Get Last discussion
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query LastDiscussion {
-              search(
-                type: DISCUSSION,
-                query: "repo:${{ inputs.repo }} in:title: \"${{ inputs.title }}\"",
-                last: 1) {
-                nodes {
-                  ... on Discussion {
-                    url
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          REPO: ${{ inputs.repo }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          search_query="repo:$REPO in:title: \"$TITLE\""
+          # shellcheck disable=SC2016
+          url=$(gh api graphql \
+            -f query='
+              query($searchQuery: String!) {
+                search(type: DISCUSSION, query: $searchQuery, last: 1) {
+                  nodes {
+                    ... on Discussion {
+                      url
+                    }
                   }
                 }
-              }
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+              }' \
+            -f searchQuery="$search_query" \
+            --jq '.data.search.nodes[0].url // empty')
+          echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/my_codeql.yml
+++ b/.github/workflows/my_codeql.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   codeql:
-    uses: route06/actions/.github/workflows/codeql.yml@v2
+    uses: ./.github/workflows/codeql.yml


### PR DESCRIPTION
## Summary

reusable workflow が内部で使用している **Node.js 16 / 20 で動作するアクション**を除去し、GitHub Actions の非推奨警告を解消します。

consumer（呼び出し元）側は **route06/actions のバージョンを更新するだけ**で警告を解消できます。

## Changes

| ファイル | 旧（deprecated） | 新 |
|---|---|---|
| `add_assignee_to_pr.yml` | `technote-space/assign-author` (**node16**) | `gh pr edit --add-assignee` |
| `get_last_discussion_url.yml` | `octokit/graphql-action@v2.x` (**node20**) | `gh api graphql` |
| `add_discussion_comment.yml` | `actions/github-script@v7` (node20) | `@v9` |
| `create_gh_discussion.yml` | `actions/github-script@v7` (node20) | `@v9` |
| `codeql.yml` | `actions/github-script@v7` (node20) | `@v9` |
| `codeql.yml` | json/yaml/yml/xml 拡張子フィルタ | 除去（JS解析対象外） |
| `my_codeql.yml` | `route06/actions/...@v2` | `./.github/workflows/codeql.yml`（dogfooding） |

## Compatibility

- 入出力・除外条件等の**挙動互換を維持**
- `add_assignee_to_pr`: Bot除外・assignee未設定の `if` 条件はそのまま
- `get_last_discussion_url`: 検索クエリと `url` 出力を維持（該当なし時は空文字）
- script injection 対策として外部入力は `env:` 経由で渡し、GraphQL では変数として渡す

## Out of scope

- `github/codeql-action@v3`（node20）→ v4 への更新は別PR (#120) で対応
- `gh_discussion_comment_to_slack.yml` / `calc_next_date.yml` / `create_gh_issue.yml` → deprecated アクションなし（変更不要）

## Related

- Supersedes #127 (DRAFT)

## Test plan

- [ ] CI (actionlint, ls-lint) がパスすること
- [ ] `add_assignee_to_pr` が PR 作成時に正しくassigneeを設定すること
- [ ] `get_last_discussion_url` が Discussion URL を正しく返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)