### PR TITLE
fix: replace deprecated technote-space/assign-author with gh CLI

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -34,4 +34,9 @@ jobs:
     if: ${{ github.event.pull_request.user.type != 'Bot' && toJSON(github.event.pull_request.assignees) == '[]' }}
 
     steps:
-      - uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160 # v1.6.2
+      - name: Add the author as an assignee
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: gh pr edit "$PR_URL" --add-assignee "$AUTHOR"


### PR DESCRIPTION
## Summary
- `technote-space/assign-author` (node16) を `gh pr edit --add-assignee` に置換
- Bot除外・assignee未設定の `if` 条件はそのまま維持

## Related
- #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)