### PR TITLE
fix: run CodeQL with actions language only for this repo

### DIFF
--- a/.github/workflows/my_codeql.yml
+++ b/.github/workflows/my_codeql.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
   pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
   merge_group:
 
 concurrency:
@@ -19,4 +25,6 @@ permissions:
 
 jobs:
   codeql:
-    uses: route06/actions/.github/workflows/codeql.yml@v2
+    uses: ./.github/workflows/codeql_core.yml
+    with:
+      language: actions


### PR DESCRIPTION
## Summary
- このリポジトリにはJSソースコードがないため、CodeQL を `actions` 言語のみで実行するよう変更
- `codeql.yml`（reusable, paths-filter で全言語自動判定）→ `codeql_core.yml` を直接 `actions` で呼び出し
- `paths` フィルタを追加し、workflow ファイル変更時のみ実行
- ローカル参照に変更（dogfooding）

## Background
yml 変更が `javascript` フィルタにマッチし、CodeQL JS スキャンが走って「JSソースコードが見つからない」エラーになっていた。

## Related
- #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)