### PR TITLE
fix: replace deprecated octokit/graphql-action with gh CLI

### DIFF
--- a/.github/workflows/get_last_discussion_url.yml
+++ b/.github/workflows/get_last_discussion_url.yml
@@ -49,25 +49,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      url: ${{ fromJSON(steps.get_last_discussion.outputs.data).search.nodes[0].url }}
+      url: ${{ steps.get_last_discussion.outputs.url }}
 
     steps:
       - id: get_last_discussion
         name: Get Last discussion
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query LastDiscussion {
-              search(
-                type: DISCUSSION,
-                query: "repo:${{ inputs.repo }} in:title: \"${{ inputs.title }}\"",
-                last: 1) {
-                nodes {
-                  ... on Discussion {
-                    url
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          REPO: ${{ inputs.repo }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          search_query="repo:$REPO in:title: \"$TITLE\""
+          # shellcheck disable=SC2016
+          url=$(gh api graphql \
+            -f query='
+              query($searchQuery: String!) {
+                search(type: DISCUSSION, query: $searchQuery, last: 1) {
+                  nodes {
+                    ... on Discussion {
+                      url
+                    }
                   }
                 }
-              }
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+              }' \
+            -f searchQuery="$search_query" \
+            --jq '.data.search.nodes[0].url // empty')
+          echo "url=$url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `octokit/graphql-action@v2.x` (node20, ADR #005違反) を `gh api graphql` に置換
- 検索クエリと `url` 出力の挙動互換を維持（該当なし時は空文字）
- script injection 対策として外部入力は `env:` 経由 + GraphQL変数で渡す

## Related
- #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)