### PR TITLE
fix: bump actions/github-script from v7 to v9

### DIFF
--- a/.github/workflows/add_discussion_comment.yml
+++ b/.github/workflows/add_discussion_comment.yml
@@ -88,7 +88,7 @@ jobs:
           DISCUSSION_ID: ${{ inputs.discussion_id }}
           COMMENT_TEMPLATE_PATH: ${{ inputs.comment_template_path }}
           REPLY_TO_COMMENT_ID: ${{ inputs.reply_to_comment_id }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -123,7 +123,7 @@ jobs:
               - added|modified: '**/*.xib'
       - name: Format filtered languages
         id: format
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const outputs = {

--- a/.github/workflows/create_gh_discussion.yml
+++ b/.github/workflows/create_gh_discussion.yml
@@ -74,7 +74,7 @@ jobs:
           CATEGORY_SLUG: ${{ inputs.category_slug }}
           TITLE: ${{ inputs.title }}
           DESCRIPTION_TEMPLATE_PATH: ${{ inputs.description_template_path }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
## Summary
- `actions/github-script` を v7 (node20) から v9 (node22) に更新
- 対象: `add_discussion_comment.yml`, `create_gh_discussion.yml`, `codeql.yml`
- Supersedes #116 (v7→v8)、v8をスキップしてv9へ直接更新

## Related
- #116
- #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)