### PR TITLE
chore: bump dorny/paths-filter from v3.0.2 to v4.0.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
       # そのため https://github.com/dorny/paths-filter を使い、フィルタのjob → 各jobの順で実行することで複数jobの分岐を実現する
       - name: Determine languages
         id: determine
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           # ここで指定したkeyがoutputsに出力される
           #


### PR DESCRIPTION
## Summary
- `dorny/paths-filter` を v3.0.2 → v4.0.1 に更新
- v4 で merge queue サポートが追加
- 他のアクションは全て最新安定バージョン確認済み（更新不要）

## 現在の全アクションバージョン状況
| アクション | バージョン | 状態 |
|---|---|---|
| `actions/checkout` | v6 (v6.0.3) | ✅ 最新 |
| `actions/create-github-app-token` | v3 (v3.2.0) | ✅ 最新 |
| `actions/dependency-review-action` | v4 (v4.9.0) | ✅ 最新 |
| `actions/github-script` | v9 (v9.0.0) | ✅ 最新 |
| `actions/setup-java` | v5 (v5.3.0) | ✅ 最新 |
| `github/codeql-action` | v4 (v4.36.2) | ✅ 最新 |
| `Songmu/tagpr` | v1.20.0 | ✅ 最新 |
| `dorny/paths-filter` | v3.0.2 → **v4.0.1** | 🔄 更新 |
| `ls-lint/action` | v2.3.1 | ✅ 最新 |
| `tokorom/action-slack-incoming-webhook` | v1.3.0 | ✅ 最新 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)