### PR TITLE
refactor: replace dorny/paths-filter with git diff in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,18 +32,6 @@
 #   codeql:
 #     uses: route06/actions/.github/workflows/codeql.yml@v2
 
-# ## Usage note
-#
-# マージキューを活用しているリポジトリでは、
-# ジョブの実行ブランチが下記の命名規則に沿ったブランチになることがある
-# gh-readonly-queue/{base_branch}/pr-{pr_num}-{base_branch_hash}
-# この場合、上述のブランチはリモートには存在しないためdorny/paths-filterが失敗する場合がある
-# その際は下記のようにブランチの除外条件を追加してください
-# on:
-#   push:
-#     branches-ignore:
-#       - gh-readonly-queue/main/pr-*
-
 name: Run CodeQL
 
 on:
@@ -55,91 +43,74 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      languages: ${{ steps.format.outputs.languages }}
+      languages: ${{ steps.determine.outputs.languages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
 
       # GitHub Actions組み込みのpathsによるフィルタでは、そのymlで実行する複数のjobそれぞれでpathsによる分岐ができない
-      # そのため https://github.com/dorny/paths-filter を使い、フィルタのjob → 各jobの順で実行することで複数jobの分岐を実現する
+      # そのためgit diffで変更ファイルの拡張子を判定し、対応するCodeQL言語を特定する
       - name: Determine languages
         id: determine
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        with:
-          # ここで指定したkeyがoutputsに出力される
-          #
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request) BASE_SHA="$PR_BASE_SHA" ;;
+            push)         BASE_SHA="$PUSH_BEFORE_SHA" ;;
+            merge_group)  BASE_SHA="$MERGE_GROUP_BASE_SHA" ;;
+            *)            BASE_SHA="HEAD~1" ;;
+          esac
+
+          changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD 2>/dev/null || echo "")
+
+          if [ -z "$changed_files" ]; then
+            echo "languages=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          languages="[]"
+
           # 拡張子の一覧は以下を参考にしている
           # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers
-          #
+
+          if echo "$changed_files" | grep -qE '(^|/)\.github/workflows/.*\.(yml|yaml)$|(^|/)action\.(yml|yaml)$'; then
+            languages=$(echo "$languages" | jq '. + ["actions"]')
+          fi
+
+          if echo "$changed_files" | grep -qE '\.go$'; then
+            languages=$(echo "$languages" | jq '. + ["go"]')
+          fi
+
+          if echo "$changed_files" | grep -qE '\.(kt|kts|ktm)$'; then
+            languages=$(echo "$languages" | jq '. + ["java"]')
+          fi
+
           # JavascriptとTypeScriptの拡張子は意図的に同じキーにまとめている
           # これはCodeQL内部で解析対象として、これらを同一に扱っていることに由来する
           # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning?learn=code_security_actions&learnProduct=code-security#changing-the-languages-that-are-analyzed
-          filters: |
-            actions:
-              - added|modified: '.github/workflows/*.yml'
-              - added|modified: '.github/workflows/*.yaml'
-              - added|modified: '**/action.yml'
-              - added|modified: '**/action.yaml'
-            go:
-              - added|modified: '**/*.go'
-            java:
-              - added|modified: '**/*.kt'
-              - added|modified: '**/*.kts'
-              - added|modified: '**/*.ktm'
-            javascript:
-              - added|modified: '**/*.js'
-              - added|modified: '**/*.jsx'
-              - added|modified: '**/*.mjs'
-              - added|modified: '**/*.es'
-              - added|modified: '**/*.es6'
-              - added|modified: '**/*.htm'
-              - added|modified: '**/*.html'
-              - added|modified: '**/*.xhtm'
-              - added|modified: '**/*.xhtml'
-              - added|modified: '**/*.vue'
-              - added|modified: '**/*.hbs'
-              - added|modified: '**/*.ejs'
-              - added|modified: '**/*.njk'
-              - added|modified: '**/*.json'
-              - added|modified: '**/*.yaml'
-              - added|modified: '**/*.yml'
-              - added|modified: '**/*.raml'
-              - added|modified: '**/*.xml'
-              - added|modified: '**/*.ts'
-              - added|modified: '**/*.tsx'
-              - added|modified: '**/*.mts'
-              - added|modified: '**/*.cts'
-            python:
-              - added|modified: '**/*.py'
-            ruby:
-              - added|modified: '**/*.rb'
-              - added|modified: '**/*.erb'
-              - added|modified: '**/*.gemspec'
-              - added|modified: '**/Gemfile'
-            swift:
-              - added|modified: '**/*.swift'
-              - added|modified: '**/*.plist'
-              - added|modified: '**/*.storyboard'
-              - added|modified: '**/*.xib'
-      - name: Format filtered languages
-        id: format
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const outputs = {
-              actions: ${{ steps.determine.outputs.actions }},
-              go: ${{ steps.determine.outputs.go }},
-              java: ${{ steps.determine.outputs.java }},
-              javascript: ${{ steps.determine.outputs.javascript }},
-              python: ${{ steps.determine.outputs.python }},
-              ruby: ${{ steps.determine.outputs.ruby }},
-              swift: ${{ steps.determine.outputs.swift }},
-            };
+          if echo "$changed_files" | grep -qE '\.(js|jsx|mjs|es|es6|htm|html|xhtm|xhtml|vue|hbs|ejs|njk|json|yaml|yml|raml|xml|ts|tsx|mts|cts)$'; then
+            languages=$(echo "$languages" | jq '. + ["javascript"]')
+          fi
 
-            const languages = Object.keys(outputs)
-              .filter(lang => outputs[lang]);
+          if echo "$changed_files" | grep -qE '\.py$'; then
+            languages=$(echo "$languages" | jq '. + ["python"]')
+          fi
 
-            core.setOutput('languages', JSON.stringify(languages));
+          if echo "$changed_files" | grep -qE '\.(rb|erb|gemspec)$|(^|/)Gemfile$'; then
+            languages=$(echo "$languages" | jq '. + ["ruby"]')
+          fi
+
+          if echo "$changed_files" | grep -qE '\.(swift|plist|storyboard|xib)$'; then
+            languages=$(echo "$languages" | jq '. + ["swift"]')
+          fi
+
+          echo "languages=$languages" >> "$GITHUB_OUTPUT"
 
   languages:
     needs: changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,8 @@ jobs:
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
+          ZERO_SHA="0000000000000000000000000000000000000000"
+
           case "$EVENT_NAME" in
             pull_request) BASE_SHA="$PR_BASE_SHA" ;;
             push)         BASE_SHA="$PUSH_BEFORE_SHA" ;;
@@ -67,7 +69,13 @@ jobs:
             *)            BASE_SHA="HEAD~1" ;;
           esac
 
-          changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD 2>/dev/null || echo "")
+          # 初回pushやforce pushではBASE_SHAがゼロSHAまたは存在しないコミットになる
+          # その場合は空ツリーとの差分を取り、全ファイルを変更対象として扱う
+          if [ "$BASE_SHA" = "$ZERO_SHA" ] || ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            BASE_SHA=$(git hash-object -t tree /dev/null)
+          fi
+
+          changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD)
 
           if [ -z "$changed_files" ]; then
             echo "languages=[]" >> "$GITHUB_OUTPUT"
@@ -80,34 +88,34 @@ jobs:
           # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers
 
           if echo "$changed_files" | grep -qE '(^|/)\.github/workflows/.*\.(yml|yaml)$|(^|/)action\.(yml|yaml)$'; then
-            languages=$(echo "$languages" | jq '. + ["actions"]')
+            languages=$(echo "$languages" | jq -c '. + ["actions"]')
           fi
 
           if echo "$changed_files" | grep -qE '\.go$'; then
-            languages=$(echo "$languages" | jq '. + ["go"]')
+            languages=$(echo "$languages" | jq -c '. + ["go"]')
           fi
 
           if echo "$changed_files" | grep -qE '\.(kt|kts|ktm)$'; then
-            languages=$(echo "$languages" | jq '. + ["java"]')
+            languages=$(echo "$languages" | jq -c '. + ["java"]')
           fi
 
           # JavascriptとTypeScriptの拡張子は意図的に同じキーにまとめている
           # これはCodeQL内部で解析対象として、これらを同一に扱っていることに由来する
           # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning?learn=code_security_actions&learnProduct=code-security#changing-the-languages-that-are-analyzed
           if echo "$changed_files" | grep -qE '\.(js|jsx|mjs|es|es6|htm|html|xhtm|xhtml|vue|hbs|ejs|njk|json|yaml|yml|raml|xml|ts|tsx|mts|cts)$'; then
-            languages=$(echo "$languages" | jq '. + ["javascript"]')
+            languages=$(echo "$languages" | jq -c '. + ["javascript"]')
           fi
 
           if echo "$changed_files" | grep -qE '\.py$'; then
-            languages=$(echo "$languages" | jq '. + ["python"]')
+            languages=$(echo "$languages" | jq -c '. + ["python"]')
           fi
 
           if echo "$changed_files" | grep -qE '\.(rb|erb|gemspec)$|(^|/)Gemfile$'; then
-            languages=$(echo "$languages" | jq '. + ["ruby"]')
+            languages=$(echo "$languages" | jq -c '. + ["ruby"]')
           fi
 
           if echo "$changed_files" | grep -qE '\.(swift|plist|storyboard|xib)$'; then
-            languages=$(echo "$languages" | jq '. + ["swift"]')
+            languages=$(echo "$languages" | jq -c '. + ["swift"]')
           fi
 
           echo "languages=$languages" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,12 +72,17 @@ jobs:
           # 初回pushやforce pushではBASE_SHAがゼロSHAまたは存在しないコミットになる
           # その場合は空ツリーとの差分を取り、全ファイルを変更対象として扱う
           if [ "$BASE_SHA" = "$ZERO_SHA" ]; then
+            echo "::warning::Base SHA is zero (initial push), scanning all files"
             BASE_SHA=$(git hash-object -t tree /dev/null)
           elif ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
-            git fetch --depth=1 origin "$BASE_SHA" 2>/dev/null || BASE_SHA=$(git hash-object -t tree /dev/null)
+            git fetch --depth=1 origin "$BASE_SHA" 2>/dev/null || {
+              echo "::warning::Base SHA unreachable, scanning all files"
+              BASE_SHA=$(git hash-object -t tree /dev/null)
+            }
           fi
 
-          changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD)
+          # --no-renames: リネームをDelete+Addに分解し、リネーム先がAMフィルタで検出されるようにする
+          changed_files=$(git diff --no-renames --name-only --diff-filter=AM "$BASE_SHA" HEAD)
 
           if [ -z "$changed_files" ]; then
             echo "languages=[]" >> "$GITHUB_OUTPUT"
@@ -89,7 +94,7 @@ jobs:
           # 拡張子の一覧は以下を参考にしている
           # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers
 
-          if echo "$changed_files" | grep -qE '(^|/)\.github/workflows/.*\.(yml|yaml)$|(^|/)action\.(yml|yaml)$'; then
+          if echo "$changed_files" | grep -qE '(^|/)\.github/workflows/[^/]*\.(yml|yaml)$|(^|/)action\.(yml|yaml)$'; then
             languages=$(echo "$languages" | jq -c '. + ["actions"]')
           fi
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       # GitHub Actions組み込みのpathsによるフィルタでは、そのymlで実行する複数のjobそれぞれでpathsによる分岐ができない
       # そのためgit diffで変更ファイルの拡張子を判定し、対応するCodeQL言語を特定する
@@ -71,8 +71,10 @@ jobs:
 
           # 初回pushやforce pushではBASE_SHAがゼロSHAまたは存在しないコミットになる
           # その場合は空ツリーとの差分を取り、全ファイルを変更対象として扱う
-          if [ "$BASE_SHA" = "$ZERO_SHA" ] || ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+          if [ "$BASE_SHA" = "$ZERO_SHA" ]; then
             BASE_SHA=$(git hash-object -t tree /dev/null)
+          elif ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            git fetch --depth=1 origin "$BASE_SHA" 2>/dev/null || BASE_SHA=$(git hash-object -t tree /dev/null)
           fi
 
           changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" HEAD)


### PR DESCRIPTION
## Summary

- `dorny/paths-filter` と `actions/github-script` の依存を削除し、`git diff` + `grep` + `jq` で変更ファイルの拡張子を判定してCodeQL言語を特定するように置き換え
- マージキューに関する Usage note を削除（dorny/paths-filter 固有の制約が解消されたため）
- `fetch-depth: 0` に変更し、`git diff` でベースコミットとの比較が可能に
- スクリプトインジェクション対策として GitHub コンテキストを `env:` 経由で渡す

## 削除される依存

- `dorny/paths-filter@v4.0.1`
- `actions/github-script@v9`（このワークフロー内のみ）

## Test plan

- [ ] PR上でCodeQL (actions) が正常に実行されることを確認
- [ ] push時にも正しく言語が検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)