### PR TITLE
Fix CodeQL action version mismatch

### DIFF
--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -35,14 +35,14 @@ jobs:
           distribution: 'corretto'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ inputs.language }}
 
       # コンパイルされた言語を解析するために必要
       # コンパイルされていない言語の場合は直ちに正常終了する
       - name: Auto build
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4


### PR DESCRIPTION
## Summary

- update the CodeQL `init` action to v4.37.3
- update the CodeQL `autobuild` action to v4.37.3
- keep all CodeQL actions on the same pinned commit

## Root cause

PR #156 updated only the `analyze` action to v4.37.3, while `init` and `autobuild` remained on v4.36.2. The analysis step rejected the configuration generated by the older action version.

## Impact

This fixes the CodeQL configuration error in PR #156 without changing the analyzed language or workflow behavior.

## Validation

- `git diff --check`
- `actionlint .github/workflows/codeql_core.yml`
- verified that `init`, `autobuild`, and `analyze` use the same pinned commit
